### PR TITLE
feat(ci): GitHub Pages dev site, PR previews, and deploy badges

### DIFF
--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -1,0 +1,207 @@
+name: GitHub Pages previews
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-dev:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: github-pages-previews
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build dev test site
+        run: pnpm build
+        env:
+          VITE_BASE_PATH: /TaiwanTaxCalculator/dev/
+          VITE_DEPLOY_CONTEXT: dev
+          VITE_DEPLOY_LABEL: DEV
+          VITE_COMMIT_SHA: ${{ github.sha }}
+
+      - name: Deploy dev test site
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages:refs/remotes/origin/gh-pages || true
+          if git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
+            git worktree add pages-worktree origin/gh-pages
+          else
+            git worktree add --orphan gh-pages pages-worktree
+          fi
+          mkdir -p pages-worktree/dev
+          rm -rf pages-worktree/dev
+          mkdir -p pages-worktree/dev
+          cp -R dist/. pages-worktree/dev/
+          touch pages-worktree/.nojekyll
+          cd pages-worktree
+          git add .nojekyll dev
+          if git diff --cached --quiet; then
+            echo "No dev test site changes to deploy."
+          else
+            git commit -m "deploy: update dev test site"
+            git push origin HEAD:gh-pages
+          fi
+
+  deploy-pr-preview:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    concurrency:
+      group: github-pages-previews
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build PR preview
+        run: pnpm build
+        env:
+          VITE_BASE_PATH: /TaiwanTaxCalculator/pr-preview/pr-${{ github.event.pull_request.number }}/
+          VITE_DEPLOY_CONTEXT: pr-preview
+          VITE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          VITE_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+
+      - name: Deploy PR preview
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages:refs/remotes/origin/gh-pages || true
+          if git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
+            git worktree add pages-worktree origin/gh-pages
+          else
+            git worktree add --orphan gh-pages pages-worktree
+          fi
+          preview_path="pages-worktree/pr-preview/pr-${{ github.event.pull_request.number }}"
+          mkdir -p "$preview_path"
+          rm -rf "$preview_path"
+          mkdir -p "$preview_path"
+          cp -R dist/. "$preview_path/"
+          touch pages-worktree/.nojekyll
+          cd pages-worktree
+          git add .nojekyll pr-preview/pr-${{ github.event.pull_request.number }}
+          if git diff --cached --quiet; then
+            echo "No PR preview changes to deploy."
+          else
+            git commit -m "deploy: update pr-${{ github.event.pull_request.number }} preview"
+            git push origin HEAD:gh-pages
+          fi
+
+      - name: Comment preview URL
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = '<!-- tax-web-pr-preview -->'
+            const previewUrl = `https://${context.repo.owner}.github.io/TaiwanTaxCalculator/pr-preview/pr-${context.issue.number}/`
+            const body = `${marker}\nPR preview: ${previewUrl}`
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            })
+            const existing = comments.find((comment) =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            )
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              })
+            }
+
+  cleanup-pr-preview:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    concurrency:
+      group: github-pages-previews
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Remove PR preview
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages:refs/remotes/origin/gh-pages || true
+          if ! git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
+            echo "No gh-pages branch exists; nothing to clean up."
+            exit 0
+          fi
+          git worktree add pages-worktree origin/gh-pages
+          preview_path="pages-worktree/pr-preview/pr-${{ github.event.pull_request.number }}"
+          if [ ! -d "$preview_path" ]; then
+            echo "No PR preview directory exists; nothing to clean up."
+            exit 0
+          fi
+          rm -rf "$preview_path"
+          cd pages-worktree
+          git add -A pr-preview
+          if git diff --cached --quiet; then
+            echo "No PR preview changes to clean up."
+          else
+            git commit -m "deploy: remove pr-${{ github.event.pull_request.number }} preview"
+            git push origin HEAD:gh-pages
+          fi

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -54,14 +54,19 @@ jobs:
           VITE_COMMIT_SHA: ${{ github.sha }}
 
       - name: Deploy dev test site
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages:refs/remotes/origin/gh-pages || true
-          if git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
-            git worktree add pages-worktree origin/gh-pages
+          remote_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git clone --branch gh-pages --single-branch "$remote_url" pages-worktree
           else
-            git worktree add --orphan gh-pages pages-worktree
+            mkdir pages-worktree
+            git -C pages-worktree init
+            git -C pages-worktree checkout -b gh-pages
+            git -C pages-worktree remote add origin "$remote_url"
           fi
           mkdir -p pages-worktree/dev
           rm -rf pages-worktree/dev
@@ -114,14 +119,19 @@ jobs:
           VITE_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Deploy PR preview
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages:refs/remotes/origin/gh-pages || true
-          if git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
-            git worktree add pages-worktree origin/gh-pages
+          remote_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git clone --branch gh-pages --single-branch "$remote_url" pages-worktree
           else
-            git worktree add --orphan gh-pages pages-worktree
+            mkdir pages-worktree
+            git -C pages-worktree init
+            git -C pages-worktree checkout -b gh-pages
+            git -C pages-worktree remote add origin "$remote_url"
           fi
           preview_path="pages-worktree/pr-preview/pr-${{ github.event.pull_request.number }}"
           mkdir -p "$preview_path"
@@ -182,15 +192,17 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Remove PR preview
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages:refs/remotes/origin/gh-pages || true
-          if ! git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
+          remote_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if ! git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
             echo "No gh-pages branch exists; nothing to clean up."
             exit 0
           fi
-          git worktree add pages-worktree origin/gh-pages
+          git clone --branch gh-pages --single-branch "$remote_url" pages-worktree
           preview_path="pages-worktree/pr-preview/pr-${{ github.event.pull_request.number }}"
           if [ ! -d "$preview_path" ]; then
             echo "No PR preview directory exists; nothing to clean up."

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -68,6 +68,8 @@ jobs:
             git -C pages-worktree checkout -b gh-pages
             git -C pages-worktree remote add origin "$remote_url"
           fi
+          git -C pages-worktree config user.name "github-actions[bot]"
+          git -C pages-worktree config user.email "github-actions[bot]@users.noreply.github.com"
           mkdir -p pages-worktree/dev
           rm -rf pages-worktree/dev
           mkdir -p pages-worktree/dev
@@ -133,6 +135,8 @@ jobs:
             git -C pages-worktree checkout -b gh-pages
             git -C pages-worktree remote add origin "$remote_url"
           fi
+          git -C pages-worktree config user.name "github-actions[bot]"
+          git -C pages-worktree config user.email "github-actions[bot]@users.noreply.github.com"
           preview_path="pages-worktree/pr-preview/pr-${{ github.event.pull_request.number }}"
           mkdir -p "$preview_path"
           rm -rf "$preview_path"
@@ -203,6 +207,8 @@ jobs:
             exit 0
           fi
           git clone --branch gh-pages --single-branch "$remote_url" pages-worktree
+          git -C pages-worktree config user.name "github-actions[bot]"
+          git -C pages-worktree config user.email "github-actions[bot]@users.noreply.github.com"
           preview_path="pages-worktree/pr-preview/pr-${{ github.event.pull_request.number }}"
           if [ ! -d "$preview_path" ]; then
             echo "No PR preview directory exists; nothing to clean up."

--- a/README.md
+++ b/README.md
@@ -67,6 +67,69 @@ pnpm -v
 | `pnpm test:watch` | 測試監看模式 |
 | `pnpm lint` | ESLint |
 
+## Deploy previews
+
+正式網站部署在 Cloudflare Pages；GitHub Pages 僅作為測試站與 PR preview。
+
+| 目標 | URL | 觸發 |
+|------|-----|------|
+| 測試站 | <https://ttw225.github.io/TaiwanTaxCalculator/dev/> | push 到 `dev` branch |
+| PR preview | `https://ttw225.github.io/TaiwanTaxCalculator/pr-preview/pr-<number>/` | PR opened / synchronized / reopened |
+
+GitHub repository 的 Pages 設定需使用 `gh-pages` branch、`/(root)` 作為 publishing source。Workflow 會保留同一個 Pages site 內的不同資料夾：
+
+```text
+dev/
+pr-preview/pr-123/
+```
+
+測試站與 PR preview build 會注入 `VITE_BASE_PATH`，避免 GitHub Pages 子路徑載入資產時壞掉；畫面上也會顯示 `DEV` 或 `PR #123` 標籤。
+
+### 本地測試 GitHub Pages 子路徑
+
+<details>
+<summary>子路徑 build／preview 指令與本機網址</summary>
+
+本地測試時，`pnpm build` 和 `pnpm preview` 都要帶同一個 `VITE_BASE_PATH`，否則 preview server 會把子路徑 asset request fallback 成 HTML，瀏覽器會顯示空白頁。
+
+測試站：
+
+```bash
+VITE_BASE_PATH=/TaiwanTaxCalculator/dev/ \
+VITE_DEPLOY_CONTEXT=dev \
+VITE_DEPLOY_LABEL=DEV \
+VITE_COMMIT_SHA=$(git rev-parse HEAD) \
+pnpm build
+
+VITE_BASE_PATH=/TaiwanTaxCalculator/dev/ pnpm preview
+```
+
+打開：
+
+```text
+http://localhost:4173/TaiwanTaxCalculator/dev/
+```
+
+PR preview：
+
+```bash
+VITE_BASE_PATH=/TaiwanTaxCalculator/pr-preview/pr-123/ \
+VITE_DEPLOY_CONTEXT=pr-preview \
+VITE_PR_NUMBER=123 \
+VITE_COMMIT_SHA=$(git rev-parse HEAD) \
+pnpm build
+
+VITE_BASE_PATH=/TaiwanTaxCalculator/pr-preview/pr-123/ pnpm preview
+```
+
+打開：
+
+```text
+http://localhost:4173/TaiwanTaxCalculator/pr-preview/pr-123/
+```
+
+</details>
+
 ## Project layout
 
 - `src/components/` — 介面元件  

--- a/src/components/DeployBadge.tsx
+++ b/src/components/DeployBadge.tsx
@@ -16,11 +16,6 @@ export function DeployBadge({ deployInfo }: Props) {
       title={deployInfo.detail ? `Commit ${deployInfo.detail}` : undefined}
     >
       <span>{deployInfo.label}</span>
-      {deployInfo.detail && (
-        <span className="hidden font-mono text-[11px] opacity-70 sm:inline">
-          {deployInfo.detail}
-        </span>
-      )}
     </span>
   )
 }

--- a/src/components/DeployBadge.tsx
+++ b/src/components/DeployBadge.tsx
@@ -1,0 +1,26 @@
+import type { DeployInfo } from '../lib/deployInfo'
+
+interface Props {
+  deployInfo: DeployInfo
+}
+
+export function DeployBadge({ deployInfo }: Props) {
+  const tone =
+    deployInfo.context === 'pr-preview'
+      ? 'border-amber-200 bg-amber-50 text-amber-800'
+      : 'border-sky-200 bg-sky-50 text-sky-800'
+
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium ${tone}`}
+      title={deployInfo.detail ? `Commit ${deployInfo.detail}` : undefined}
+    >
+      <span>{deployInfo.label}</span>
+      {deployInfo.detail && (
+        <span className="hidden font-mono text-[11px] opacity-70 sm:inline">
+          {deployInfo.detail}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink } from 'lucide-react'
+import { getDeployInfo } from '../lib/deployInfo'
 import { SITE_CONFIG } from '../lib/siteConfig'
 
 export function SiteFooter() {
@@ -6,6 +7,7 @@ export function SiteFooter() {
     name, nameEn, taxYear, dataYear, lastUpdated,
     buyMeCoffeeUrl, githubNewIssueUrl, officialLinks,
   } = SITE_CONFIG
+  const deployInfo = getDeployInfo()
 
   return (
     <footer className="mt-16 border-t border-gray-200 bg-white">
@@ -117,6 +119,12 @@ export function SiteFooter() {
           <span>資料年度：{taxYear} 年度（{dataYear} 年 5 月申報）</span>
           <span className="hidden sm:inline">·</span>
           <span>最後更新：{lastUpdated}</span>
+          {deployInfo && (
+            <>
+              <span className="hidden sm:inline">·</span>
+              <span>{deployInfo.label}{deployInfo.detail ? ` · ${deployInfo.detail}` : ''}</span>
+            </>
+          )}
         </div>
       </div>
     </footer>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react'
 import { Menu, X } from 'lucide-react'
 import { NAV_ITEMS, SITE_CONFIG } from '../lib/siteConfig'
+import { getDeployInfo } from '../lib/deployInfo'
 import { ComingSoonNavItem } from './ComingSoonNavItem'
+import { DeployBadge } from './DeployBadge'
 
 interface Props {
   currentFeatureId: string
@@ -9,6 +11,7 @@ interface Props {
 
 export function SiteHeader({ currentFeatureId }: Props) {
   const [menuOpen, setMenuOpen] = useState(false)
+  const deployInfo = getDeployInfo()
 
   // Close on Escape
   useEffect(() => {
@@ -32,13 +35,16 @@ export function SiteHeader({ currentFeatureId }: Props) {
       <div className="max-w-5xl mx-auto px-4 h-14 flex items-center justify-between">
 
         {/* Logo — left-aligned on all viewports (Task 1.2) */}
-        <div className="flex flex-col leading-tight">
-          <span className="font-semibold text-gray-900 text-base tracking-tight">
-            {SITE_CONFIG.name}
-          </span>
-          <span className="text-xs text-gray-400 hidden sm:block">
-            {SITE_CONFIG.nameEn}
-          </span>
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex min-w-0 flex-col leading-tight">
+            <span className="truncate font-semibold text-gray-900 text-base tracking-tight">
+              {SITE_CONFIG.name}
+            </span>
+            <span className="hidden text-xs text-gray-400 sm:block">
+              {SITE_CONFIG.nameEn}
+            </span>
+          </div>
+          {deployInfo && <DeployBadge deployInfo={deployInfo} />}
         </div>
 
         {/* Desktop nav */}

--- a/src/lib/deployInfo.ts
+++ b/src/lib/deployInfo.ts
@@ -1,0 +1,35 @@
+export type DeployContext = 'dev' | 'pr-preview'
+
+export interface DeployInfo {
+  context: DeployContext
+  label: string
+  detail?: string
+}
+
+function shortSha(value: string | undefined) {
+  return value ? value.slice(0, 7) : undefined
+}
+
+export function getDeployInfo(): DeployInfo | null {
+  const context = import.meta.env.VITE_DEPLOY_CONTEXT
+  const commitSha = shortSha(import.meta.env.VITE_COMMIT_SHA)
+
+  if (context === 'dev') {
+    return {
+      context,
+      label: import.meta.env.VITE_DEPLOY_LABEL || 'DEV',
+      detail: commitSha,
+    }
+  }
+
+  if (context === 'pr-preview') {
+    const prNumber = import.meta.env.VITE_PR_NUMBER
+    return {
+      context,
+      label: prNumber ? `PR #${prNumber}` : 'PR',
+      detail: commitSha,
+    }
+  }
+
+  return null
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: process.env.VITE_BASE_PATH ?? '/',
   plugins: [react(), tailwindcss()],
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

- Add pages-preview workflow: deploy dev on push to dev, PR previews with bot comment, cleanup preview folder on PR close
- Set Vite base from VITE_BASE_PATH for gh-pages subpaths
- Add deployInfo + DeployBadge (DEV / PR #n + short SHA) in header/footer
- Document preview URLs and local subpath build in README

## Checks

- [x] No personal tax data or private documents included
- [x] Tax-related claims are sourced or marked as draft
- [x] Changes are scoped to this PR
