### PR TITLE
feat(ci): generate gh-pages index.html for preview hub

### DIFF
--- a/.github/scripts/render-pages-index.sh
+++ b/.github/scripts/render-pages-index.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="${1:?Usage: render-pages-index.sh <pages-root>}"
+production_url="${PRODUCTION_URL:-https://taiwantaxcalculator.com/}"
+generated_at="$(date -u +"%Y-%m-%d %H:%M UTC")"
+pr_links=""
+
+if [ -d "$root/pr-preview" ]; then
+  while IFS= read -r preview_dir; do
+    pr_name="$(basename "$preview_dir")"
+    pr_number="${pr_name#pr-}"
+    pr_links="${pr_links}<li><a href=\"pr-preview/${pr_name}/\"><span>PR #${pr_number}</span><small>/pr-preview/${pr_name}/</small></a></li>"
+  done < <(find "$root/pr-preview" -mindepth 1 -maxdepth 1 -type d -name 'pr-*' | sort -V)
+fi
+
+if [ -z "$pr_links" ]; then
+  pr_links="<li class=\"empty\">目前沒有可用的 PR preview</li>"
+fi
+
+cat > "$root/index.html" <<EOF
+<!doctype html>
+<html lang="zh-Hant-TW">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TaiwanTaxCalculator previews</title>
+    <style>
+      :root { color-scheme: light; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #172033; background: #f6f8fb; }
+      body { margin: 0; min-height: 100vh; }
+      main { width: min(760px, calc(100% - 32px)); margin: 0 auto; padding: 56px 0; }
+      h1 { margin: 0 0 8px; font-size: clamp(28px, 5vw, 42px); line-height: 1.05; letter-spacing: 0; }
+      p { margin: 0; color: #5d687a; line-height: 1.7; }
+      section { margin-top: 28px; }
+      h2 { margin: 0 0 12px; font-size: 13px; letter-spacing: .08em; text-transform: uppercase; color: #738095; }
+      ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 10px; }
+      a, .empty { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 16px 18px; border: 1px solid #dfe6ef; border-radius: 8px; background: #fff; color: #172033; text-decoration: none; box-shadow: 0 1px 2px rgb(15 23 42 / 4%); }
+      a:hover { border-color: #8fb8b4; box-shadow: 0 8px 24px rgb(15 23 42 / 8%); }
+      span { font-weight: 650; }
+      small { color: #697589; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; font-size: 12px; text-align: right; }
+      .empty { color: #7a8495; justify-content: flex-start; }
+      footer { margin-top: 28px; color: #8a95a6; font-size: 12px; }
+      @media (max-width: 560px) {
+        a { align-items: flex-start; flex-direction: column; }
+        small { text-align: left; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>TaiwanTaxCalculator</h1>
+      <p>測試站與 PR preview 入口。正式網站部署在 Cloudflare Pages。</p>
+
+      <section>
+        <h2>Main branch</h2>
+        <ul>
+          <li><a href="${production_url}"><span>Production</span><small>${production_url}</small></a></li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Dev branch</h2>
+        <ul>
+          <li><a href="dev/"><span>DEV</span><small>/dev/</small></a></li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Pull requests</h2>
+        <ul>${pr_links}</ul>
+      </section>
+
+      <footer>Updated ${generated_at}</footer>
+    </main>
+  </body>
+</html>
+EOF

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -75,8 +75,9 @@ jobs:
           mkdir -p pages-worktree/dev
           cp -R dist/. pages-worktree/dev/
           touch pages-worktree/.nojekyll
+          bash .github/scripts/render-pages-index.sh pages-worktree
           cd pages-worktree
-          git add .nojekyll dev
+          git add .nojekyll index.html dev
           if git diff --cached --quiet; then
             echo "No dev test site changes to deploy."
           else
@@ -143,8 +144,9 @@ jobs:
           mkdir -p "$preview_path"
           cp -R dist/. "$preview_path/"
           touch pages-worktree/.nojekyll
+          bash .github/scripts/render-pages-index.sh pages-worktree
           cd pages-worktree
-          git add .nojekyll pr-preview/pr-${{ github.event.pull_request.number }}
+          git add .nojekyll index.html pr-preview/pr-${{ github.event.pull_request.number }}
           if git diff --cached --quiet; then
             echo "No PR preview changes to deploy."
           else
@@ -215,8 +217,9 @@ jobs:
             exit 0
           fi
           rm -rf "$preview_path"
+          bash .github/scripts/render-pages-index.sh pages-worktree
           cd pages-worktree
-          git add -A pr-preview
+          git add -A index.html pr-preview
           if git diff --cached --quiet; then
             echo "No PR preview changes to clean up."
           else

--- a/README.md
+++ b/README.md
@@ -79,9 +79,12 @@ pnpm -v
 GitHub repository 的 Pages 設定需使用 `gh-pages` branch、`/(root)` 作為 publishing source。Workflow 會保留同一個 Pages site 內的不同資料夾：
 
 ```text
+index.html
 dev/
 pr-preview/pr-123/
 ```
+
+<https://ttw225.github.io/TaiwanTaxCalculator/> 會顯示一個簡單入口頁，列出 production、dev 與目前存在的 PR preview。入口頁由 `.github/scripts/render-pages-index.sh` 在部署與 cleanup 時重新產生。
 
 測試站與 PR preview build 會注入 `VITE_BASE_PATH`，避免 GitHub Pages 子路徑載入資產時壞掉；畫面上也會顯示 `DEV` 或 `PR #123` 標籤。
 


### PR DESCRIPTION
## Summary

- Add render-pages-index.sh to list production, dev/, and pr-preview/pr-*
- Run script after dev deploy, PR preview deploy, and PR preview cleanup
- Stage index.html with each gh-pages push; document in README

## Checks

- [x] No personal tax data or private documents included
- [x] Tax-related claims are sourced or marked as draft
- [x] Changes are scoped to this PR
