### PR TITLE
feat(back-to-the-top-button): add back-to-top button and smooth scroll animation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import type { RemovalImpactPreview } from './components/ChecklistResult'
 import { PersonalizedTaxPage } from './components/PersonalizedTaxPage'
 import { SiteHeader } from './components/SiteHeader'
 import { SiteFooter } from './components/SiteFooter'
+import { BackToTopButton } from './components/BackToTopButton'
 
 const PUBLISHED_ITEMS = applyPublicationGate(CHECKLIST_ITEMS)
 const SITUATION_IDS = SITUATIONS.map((s) => s.id)
@@ -427,6 +428,7 @@ function App() {
         {content}
       </main>
       <SiteFooter />
+      <BackToTopButton />
     </div>
   )
 }

--- a/src/components/BackToTopButton.tsx
+++ b/src/components/BackToTopButton.tsx
@@ -1,0 +1,40 @@
+import { ChevronUp } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { animateScrollToY } from '../lib/scrollAnimation'
+
+const SHOW_THRESHOLD_PX = 240
+
+export function BackToTopButton() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    function updateVisibility() {
+      setVisible(window.scrollY > SHOW_THRESHOLD_PX)
+    }
+
+    updateVisibility()
+    window.addEventListener('scroll', updateVisibility, { passive: true })
+
+    return () => {
+      window.removeEventListener('scroll', updateVisibility)
+    }
+  }, [])
+
+  function handleBackToTop() {
+    animateScrollToY(0)
+  }
+
+  if (!visible) return null
+
+  return (
+    <button
+      type="button"
+      data-testid="back-to-top-btn"
+      aria-label="回到頁面頂部"
+      onClick={handleBackToTop}
+      className="no-print fixed right-4 bottom-4 z-40 inline-flex h-10 w-10 items-center justify-center rounded-full border border-gray-300 bg-gray-100 text-gray-600 shadow-sm transition-colors hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 md:right-6 md:bottom-6"
+    >
+      <ChevronUp size={18} aria-hidden="true" />
+    </button>
+  )
+}

--- a/src/components/ChecklistResult.tsx
+++ b/src/components/ChecklistResult.tsx
@@ -8,6 +8,7 @@ import type {
 import type { CategoryGroup } from '../lib/checklist'
 import { formatChecklistMarkdown } from '../lib/exportChecklist'
 import { getNumber } from '../lib/numbers'
+import { animateScrollToY } from '../lib/scrollAnimation'
 import { ITEM_INLINE_FIELDS } from '../content/inlineFields'
 import { DecisionToolsPanel } from './DecisionToolsPanel'
 import { DeductionCard } from './DeductionCard'
@@ -423,7 +424,11 @@ export function ChecklistResult({
     if (!scrollToItemId) return
     const target = itemRefs.current[scrollToItemId]
     if (target) {
-      target.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'smooth' })
+      const targetRect = target.getBoundingClientRect()
+      const targetCenterY = targetRect.top + window.scrollY + targetRect.height / 2
+      const viewportCenterY = window.innerHeight / 2
+      const targetY = Math.max(0, Math.round(targetCenterY - viewportCenterY))
+      animateScrollToY(targetY)
     }
     onScrollHandled?.()
   }, [onScrollHandled, scrollToItemId])

--- a/src/lib/scrollAnimation.ts
+++ b/src/lib/scrollAnimation.ts
@@ -1,0 +1,61 @@
+const DEFAULT_SCROLL_DURATION_MS = 1000
+
+let activeRafId: number | null = null
+
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3)
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window.matchMedia !== 'function') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+export function cancelScrollAnimation() {
+  if (activeRafId !== null) {
+    cancelAnimationFrame(activeRafId)
+    activeRafId = null
+  }
+}
+
+export function animateScrollToY(
+  targetY: number,
+  options?: { durationMs?: number },
+) {
+  cancelScrollAnimation()
+
+  const durationMs = options?.durationMs ?? DEFAULT_SCROLL_DURATION_MS
+  const normalizedTargetY = Math.max(0, Math.round(targetY))
+
+  if (prefersReducedMotion()) {
+    window.scrollTo(0, normalizedTargetY)
+    return
+  }
+
+  const startY = window.scrollY
+  if (startY === normalizedTargetY) {
+    window.scrollTo(0, normalizedTargetY)
+    return
+  }
+
+  let startTimestamp: number | null = null
+  const step = (timestamp: number) => {
+    if (startTimestamp === null) startTimestamp = timestamp
+
+    const elapsed = timestamp - startTimestamp
+    const progress = Math.min(elapsed / durationMs, 1)
+    const eased = easeOutCubic(progress)
+    const nextY = Math.round(startY + (normalizedTargetY - startY) * eased)
+
+    window.scrollTo(0, nextY)
+
+    if (progress < 1) {
+      activeRafId = requestAnimationFrame(step)
+      return
+    }
+
+    activeRafId = null
+  }
+
+  activeRafId = requestAnimationFrame(step)
+}

--- a/tests/back-to-top-button.test.tsx
+++ b/tests/back-to-top-button.test.tsx
@@ -1,0 +1,165 @@
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BackToTopButton } from '../src/components/BackToTopButton'
+
+let container: HTMLDivElement
+let root: Root | null
+let scrollYValue = 0
+let scrollToSpy: ReturnType<typeof vi.fn>
+let rafCallbacks: Array<FrameRequestCallback | undefined>
+let requestAnimationFrameSpy: ReturnType<typeof vi.fn>
+
+function setScrollY(next: number) {
+  scrollYValue = next
+}
+
+function runNextAnimationFrame(timestamp: number) {
+  const callback = rafCallbacks.find((cb) => cb !== undefined)
+  const callbackIndex = rafCallbacks.findIndex((cb) => cb !== undefined)
+  if (!callback || callbackIndex < 0) return
+  rafCallbacks[callbackIndex] = undefined
+  callback(timestamp)
+}
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+  root = null
+  container = document.createElement('div')
+  document.body.appendChild(container)
+
+  setScrollY(0)
+  Object.defineProperty(window, 'scrollY', {
+    get: () => scrollYValue,
+    configurable: true,
+  })
+
+  scrollToSpy = vi.fn((x: number, y: number) => {
+    void x
+    setScrollY(y)
+  })
+  Object.defineProperty(window, 'scrollTo', {
+    value: scrollToSpy,
+    configurable: true,
+  })
+
+  rafCallbacks = []
+  requestAnimationFrameSpy = vi.fn((cb: FrameRequestCallback) => {
+    rafCallbacks.push(cb)
+    return rafCallbacks.length
+  })
+
+  Object.defineProperty(window, 'requestAnimationFrame', {
+    value: requestAnimationFrameSpy,
+    configurable: true,
+  })
+  Object.defineProperty(window, 'cancelAnimationFrame', {
+    value: vi.fn((id: number) => {
+      if (id > 0 && id <= rafCallbacks.length) rafCallbacks[id - 1] = undefined
+    }),
+    configurable: true,
+  })
+
+  Object.defineProperty(window, 'matchMedia', {
+    value: vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+    configurable: true,
+  })
+})
+
+afterEach(() => {
+  if (root) {
+    act(() => {
+      root?.unmount()
+    })
+    root = null
+  }
+  document.body.removeChild(container)
+})
+
+function renderButton() {
+  const nextRoot = createRoot(container)
+  root = nextRoot
+  act(() => {
+    nextRoot.render(createElement(BackToTopButton))
+  })
+  return nextRoot
+}
+
+describe('BackToTopButton', () => {
+  it('is hidden when user is near top', () => {
+    renderButton()
+    const button = container.querySelector('[data-testid="back-to-top-btn"]')
+    expect(button).toBeNull()
+  })
+
+  it('shows after scrolling beyond threshold', () => {
+    renderButton()
+    act(() => {
+      setScrollY(241)
+      window.dispatchEvent(new Event('scroll'))
+    })
+    const button = container.querySelector<HTMLElement>('[data-testid="back-to-top-btn"]')
+    expect(button).not.toBeNull()
+    expect(button?.getAttribute('aria-label')).toBe('回到頁面頂部')
+    expect(button?.textContent?.trim()).toBe('')
+  })
+
+  it('animates back to top over custom duration', () => {
+    setScrollY(600)
+    renderButton()
+    const button = container.querySelector<HTMLElement>('[data-testid="back-to-top-btn"]')
+    if (!button) throw new Error('Missing back to top button')
+
+    act(() => {
+      button.click()
+    })
+
+    act(() => {
+      runNextAnimationFrame(0)
+      runNextAnimationFrame(500)
+      runNextAnimationFrame(1000)
+    })
+
+    expect(requestAnimationFrameSpy).toHaveBeenCalled()
+    expect(scrollToSpy).toHaveBeenCalled()
+    expect(scrollToSpy).toHaveBeenLastCalledWith(0, 0)
+  })
+
+  it('jumps immediately to top for reduced-motion users', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      value: vi.fn((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+      configurable: true,
+    })
+
+    setScrollY(500)
+    renderButton()
+    const button = container.querySelector<HTMLElement>('[data-testid="back-to-top-btn"]')
+    if (!button) throw new Error('Missing back to top button')
+
+    act(() => {
+      button.click()
+    })
+
+    expect(requestAnimationFrameSpy).not.toHaveBeenCalled()
+    expect(scrollToSpy).toHaveBeenLastCalledWith(0, 0)
+  })
+})

--- a/tests/situation-single-source-flow.test.tsx
+++ b/tests/situation-single-source-flow.test.tsx
@@ -8,20 +8,97 @@ const LEGACY_MANUAL_OVERRIDES_STORAGE_KEY = 'tax.checklist.manualOverrides.v1'
 
 let container: HTMLDivElement
 let scrollToSpy: ReturnType<typeof vi.fn>
-let scrollIntoViewSpy: ReturnType<typeof vi.fn>
-let lastScrollTargetTestId: string | null
+let scrollYValue = 0
+let rafCallbacks: Array<FrameRequestCallback | undefined>
+let requestAnimationFrameSpy: ReturnType<typeof vi.fn>
+
+const DONATION_TARGET_TOP = 900
+const DONATION_TARGET_HEIGHT = 120
+const VIEWPORT_HEIGHT = 800
+
+function runNextAnimationFrame(timestamp: number) {
+  const callback = rafCallbacks.find((cb) => cb !== undefined)
+  const callbackIndex = rafCallbacks.findIndex((cb) => cb !== undefined)
+  if (!callback || callbackIndex < 0) return
+  rafCallbacks[callbackIndex] = undefined
+  callback(timestamp)
+}
 
 beforeEach(() => {
   ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
   localStorage.clear()
-  scrollToSpy = vi.fn()
-  lastScrollTargetTestId = null
-  scrollIntoViewSpy = vi.fn(function (this: HTMLElement) {
-    lastScrollTargetTestId = this.getAttribute('data-testid')
+  scrollYValue = 0
+  Object.defineProperty(window, 'scrollY', {
+    get: () => scrollYValue,
+    configurable: true,
+  })
+
+  scrollToSpy = vi.fn((x: number, y: number) => {
+    void x
+    scrollYValue = y
   })
   Object.defineProperty(window, 'scrollTo', { value: scrollToSpy, configurable: true })
-  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
-    value: scrollIntoViewSpy,
+
+  rafCallbacks = []
+  requestAnimationFrameSpy = vi.fn((cb: FrameRequestCallback) => {
+    rafCallbacks.push(cb)
+    return rafCallbacks.length
+  })
+  Object.defineProperty(window, 'requestAnimationFrame', {
+    value: requestAnimationFrameSpy,
+    configurable: true,
+  })
+  Object.defineProperty(window, 'cancelAnimationFrame', {
+    value: vi.fn((id: number) => {
+      if (id > 0 && id <= rafCallbacks.length) rafCallbacks[id - 1] = undefined
+    }),
+    configurable: true,
+  })
+  Object.defineProperty(window, 'matchMedia', {
+    value: vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+    configurable: true,
+  })
+  Object.defineProperty(window, 'innerHeight', {
+    value: VIEWPORT_HEIGHT,
+    configurable: true,
+  })
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    value: function (this: HTMLElement) {
+      const testId = this.getAttribute('data-testid')
+      if (testId === 'checklist-item-donations-deduction') {
+        return {
+          x: 0,
+          y: DONATION_TARGET_TOP,
+          top: DONATION_TARGET_TOP,
+          left: 0,
+          bottom: DONATION_TARGET_TOP + DONATION_TARGET_HEIGHT,
+          right: 640,
+          width: 640,
+          height: DONATION_TARGET_HEIGHT,
+          toJSON: () => '',
+        }
+      }
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        width: 0,
+        height: 0,
+        toJSON: () => '',
+      }
+    },
     configurable: true,
   })
   container = document.createElement('div')
@@ -77,8 +154,14 @@ describe('situation single-source flow', () => {
     clickByTestId('add-situation-checkbox-rent')
     clickByTestId('add-situation-checkbox-donations')
     clickByTestId('confirm-add-situations-btn')
-    expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: 'center', inline: 'nearest', behavior: 'smooth' })
-    expect(lastScrollTargetTestId).toBe('checklist-item-donations-deduction')
+    act(() => {
+      runNextAnimationFrame(0)
+      runNextAnimationFrame(500)
+      runNextAnimationFrame(1000)
+    })
+    const expectedTargetY = DONATION_TARGET_TOP + DONATION_TARGET_HEIGHT / 2 - VIEWPORT_HEIGHT / 2
+    expect(requestAnimationFrameSpy).toHaveBeenCalled()
+    expect(scrollToSpy).toHaveBeenLastCalledWith(0, expectedTargetY)
     expect(container.textContent).toContain('房屋租金扣除額（需進一步確認）')
     expect(container.textContent).toContain('捐贈扣除額')
 
@@ -124,7 +207,7 @@ describe('situation single-source flow', () => {
     clickByTestId('add-situation-checkbox-rent')
     clickByTestId('cancel-add-situations-btn')
 
-    expect(scrollIntoViewSpy).not.toHaveBeenCalled()
+    expect(requestAnimationFrameSpy).not.toHaveBeenCalled()
     expect(container.textContent).not.toContain('房屋租金扣除額（需進一步確認）')
   })
 


### PR DESCRIPTION
## Summary
- Add BackToTopButton component with visibility threshold
- Implement animateScrollToY utility using requestAnimationFrame and cubic easing
- Replace native scrollIntoView with custom smooth scroll in ChecklistResult for better
- Support prefers-reduced-motion to skip animations for accessible UX
- Add comprehensive tests for scroll animation and back-to-top button behavior
- Update existing integration tests to verify new scroll logic

## Checks

- [x] No personal tax data or private documents included
- [x] Tax-related claims are sourced or marked as draft
- [x] Changes are scoped to this PR
