### PR TITLE
feat(card-in-page-2): remove not needed labels and buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type {
   CardInputMap,
-  CardStatusMap,
   ChecklistItem,
   Situation,
   SituationId,
@@ -101,22 +100,11 @@ function getAddableSituationGroups(
 function hasCardData(
   itemId: string,
   cardInputMap: CardInputMap,
-  cardStatusMap: CardStatusMap,
 ): boolean {
-  const hasInput = Object.values(cardInputMap[itemId] ?? {}).some((value) => value !== '')
-  const hasStatus = (cardStatusMap[itemId] ?? 'unset') !== 'unset'
-  return hasInput || hasStatus
+  return Object.values(cardInputMap[itemId] ?? {}).some((value) => value !== '')
 }
 
 function omitIdsFromCardInputMap(map: CardInputMap, itemIds: string[]): CardInputMap {
-  const next = { ...map }
-  for (const itemId of itemIds) {
-    delete next[itemId]
-  }
-  return next
-}
-
-function omitIdsFromCardStatusMap(map: CardStatusMap, itemIds: string[]): CardStatusMap {
   const next = { ...map }
   for (const itemId of itemIds) {
     delete next[itemId]
@@ -181,7 +169,6 @@ function App() {
   const [appState, setAppState] = useState<AppState>('selecting')
   const [selected, setSelected] = useState<SituationId[]>(() => loadSavedSituationSelection(SITUATION_IDS))
   const [cardInputMap, setCardInputMap] = useState<CardInputMap>({})
-  const [cardStatusMap, setCardStatusMap] = useState<CardStatusMap>({})
   const [taxProfile, setTaxProfile] = useState<TaxProfile>(() => loadSavedTaxProfile())
   const [profilePersistence, setProfilePersistence] = useState<TaxProfilePersistenceMode>(() =>
     hasSavedTaxProfile() ? 'local' : 'session',
@@ -240,7 +227,6 @@ function App() {
   function handleReset() {
     setAppState('selecting')
     setCardInputMap({})
-    setCardStatusMap({})
     setSortedCardInputMap({})
     setPendingRemovalEffect(null)
     setScrollToItemId(null)
@@ -250,7 +236,6 @@ function App() {
     setSelected([])
     setAppState('selecting')
     setCardInputMap({})
-    setCardStatusMap({})
     setSortedCardInputMap({})
     setPendingRemovalEffect(null)
     setScrollToItemId(null)
@@ -284,7 +269,7 @@ function App() {
       .map((id) => SITUATION_LABEL_BY_ID.get(id) ?? id)
     const removedItemTitles = removedItemIds
       .map((id) => ITEM_BY_ID.get(id)?.title ?? id)
-    const hasInputLoss = removedItemIds.some((id) => hasCardData(id, cardInputMap, cardStatusMap))
+    const hasInputLoss = removedItemIds.some((id) => hasCardData(id, cardInputMap))
 
     return {
       nextSelected,
@@ -303,7 +288,6 @@ function App() {
   function applyRemovalEffect(effect: RemovalEffect) {
     setSelected(effect.nextSelected)
     setCardInputMap((prev) => omitIdsFromCardInputMap(prev, effect.removedItemIds))
-    setCardStatusMap((prev) => omitIdsFromCardStatusMap(prev, effect.removedItemIds))
     setSortedCardInputMap((prev) => omitIdsFromCardInputMap(prev, effect.removedItemIds))
     if (effect.nextSelected.length === 0) {
       // Keep this behavior as the canonical UX: empty checklist returns to page one.
@@ -348,10 +332,6 @@ function App() {
     })
   }, [])
 
-  function handleCardStatusChange(itemId: string, status: 'confirmed' | 'na') {
-    setCardStatusMap((prev) => ({ ...prev, [itemId]: status }))
-  }
-
   function handleTaxProfileChange(patch: Partial<TaxProfile>) {
     setTaxProfile((prev) => normalizeTaxProfile({ ...prev, ...patch }))
   }
@@ -395,10 +375,8 @@ function App() {
           itemSourceSituationLabelsById={itemSourceSituationLabelsById}
           addableSituationGroups={addableSituationGroups}
           cardInputMap={cardInputMap}
-          cardStatusMap={cardStatusMap}
           pendingRemovalImpact={pendingRemovalEffect?.preview ?? null}
           onCardInputChange={handleCardInputChange}
-          onCardStatusChange={handleCardStatusChange}
           onOpenPersonalized={() => setAppState('personalized')}
           onAddSituations={handleAddSituations}
           onRemoveItem={handleRemoveItem}

--- a/src/components/ChecklistResult.tsx
+++ b/src/components/ChecklistResult.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import type {
   CardInputMap,
-  CardStatusMap,
   Situation,
   SituationId,
 } from '../types/content'
@@ -35,10 +34,8 @@ interface Props {
   itemSourceSituationLabelsById?: Record<string, string[]>
   addableSituationGroups?: AddableSituationGroup[]
   cardInputMap: CardInputMap
-  cardStatusMap: CardStatusMap
   pendingRemovalImpact?: RemovalImpactPreview | null
   onCardInputChange: (itemId: string, fieldId: string, value: string) => void
-  onCardStatusChange: (itemId: string, status: 'confirmed' | 'na') => void
   onOpenPersonalized: () => void
   onReset?: () => void
   onAddSituations?: (ids: SituationId[]) => void
@@ -277,7 +274,7 @@ function RemoveImpactDialog({
 
           {impact.hasInputLoss && (
             <p className="rounded border border-amber-200 bg-amber-50 px-2 py-1 text-amber-700">
-              此次移除會清除已填寫的資料或已設定的卡片狀態。
+              此次移除會清除已填寫的資料。
             </p>
           )}
         </div>
@@ -400,10 +397,8 @@ export function ChecklistResult({
   itemSourceSituationLabelsById = {},
   addableSituationGroups = [],
   cardInputMap,
-  cardStatusMap,
   pendingRemovalImpact,
   onCardInputChange,
-  onCardStatusChange,
   onOpenPersonalized,
   onAddSituations,
   onRemoveItem,
@@ -550,11 +545,9 @@ export function ChecklistResult({
                     item={item}
                     inlineFields={ITEM_INLINE_FIELDS[item.id] ?? []}
                     inputValues={cardInputMap[item.id] ?? {}}
-                    status={cardStatusMap[item.id] ?? 'unset'}
                     sourceSituationLabels={itemSourceSituationLabelsById[item.id] ?? []}
                     removable
                     onInputChange={(fieldId, value) => onCardInputChange(item.id, fieldId, value)}
-                    onStatusChange={(status) => onCardStatusChange(item.id, status)}
                     onRemove={() => onRemoveItem?.(item.id)}
                   />
                 </div>

--- a/src/components/DeductionCard.tsx
+++ b/src/components/DeductionCard.tsx
@@ -1,27 +1,19 @@
-import type { CardInlineField, CardStatus, ChecklistItem, DisclaimerLevel } from '../types/content'
+import type { CardInlineField, ChecklistItem, DisclaimerLevel } from '../types/content'
 import { getNumber } from '../lib/numbers'
 
 interface Props {
   item: ChecklistItem
   inlineFields?: CardInlineField[]
   inputValues?: Record<string, string>
-  status?: CardStatus
   sourceSituationLabels?: string[]
   removable?: boolean
   onInputChange?: (fieldId: string, value: string) => void
-  onStatusChange?: (status: 'confirmed' | 'na') => void
   onRemove?: () => void
 }
 
-const DISCLAIMER_BADGE: Record<DisclaimerLevel, { label: string; className: string }> = {
-  low: { label: '文件準備', className: 'bg-gray-100 text-gray-600' },
+const DISCLAIMER_BADGE: Partial<Record<DisclaimerLevel, { label: string; className: string }>> = {
   medium: { label: '建議確認', className: 'bg-yellow-100 text-yellow-700' },
   high: { label: '需進一步確認', className: 'bg-orange-100 text-orange-700' },
-}
-
-const STATUS_BADGE: Record<'confirmed' | 'na', { label: string; className: string }> = {
-  confirmed: { label: '確認適用', className: 'bg-green-100 text-green-700' },
-  na: { label: '不適用', className: 'bg-gray-100 text-gray-400' },
 }
 
 const HIGH_RISK_NOTICE = '此項涉及個人條件或排富規定，請以財政部電子申報系統與官方資料確認。'
@@ -66,11 +58,9 @@ export function DeductionCard({
   item,
   inlineFields = [],
   inputValues = {},
-  status = 'unset',
   sourceSituationLabels = [],
   removable = false,
   onInputChange,
-  onStatusChange,
   onRemove,
 }: Props) {
   const badge = DISCLAIMER_BADGE[item.disclaimer_level]
@@ -83,14 +73,11 @@ export function DeductionCard({
       <div className="flex items-start gap-2 mb-2">
         <h3 className="font-medium text-gray-900 flex-1 text-sm">{item.title}</h3>
         <div className="flex items-center gap-1.5 flex-shrink-0">
-          {status !== 'unset' && (
-            <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_BADGE[status].className}`}>
-              {STATUS_BADGE[status].label}
+          {badge && (
+            <span className={`text-xs px-2 py-0.5 rounded-full font-medium whitespace-nowrap ${badge.className}`}>
+              {badge.label}
             </span>
           )}
-          <span className={`text-xs px-2 py-0.5 rounded-full font-medium whitespace-nowrap ${badge.className}`}>
-            {badge.label}
-          </span>
           {removable && onRemove && (
             <button
               type="button"
@@ -184,27 +171,6 @@ export function DeductionCard({
         <p className="text-xs font-medium text-blue-700 mb-1">→ {item.next_action}</p>
         {item.disclaimer_level === 'high' && (
           <p className="mb-2 text-xs text-orange-700">{HIGH_RISK_NOTICE}</p>
-        )}
-
-        {status === 'unset' && onStatusChange && (
-          <div className="flex gap-2 mb-2">
-            <button
-              type="button"
-              onClick={() => onStatusChange('confirmed')}
-              data-testid={`card-status-confirmed-${item.id}`}
-              className="text-xs px-2.5 py-1 rounded border border-green-300 bg-green-50 text-green-700 hover:bg-green-100"
-            >
-              確認適用
-            </button>
-            <button
-              type="button"
-              onClick={() => onStatusChange('na')}
-              data-testid={`card-status-na-${item.id}`}
-              className="text-xs px-2.5 py-1 rounded border border-gray-200 bg-white text-gray-500 hover:bg-gray-50"
-            >
-              不適用
-            </button>
-          </div>
         )}
 
         <details className="group">

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -68,10 +68,6 @@ export interface CardInlineField {
 
 export type CardInputMap = Record<string, Record<string, string>>
 
-export type CardStatus = 'unset' | 'confirmed' | 'na'
-
-export type CardStatusMap = Record<string, CardStatus>
-
 export type DecisionToolId = 'dividend' | 'couple_filing' | 'amt'
 
 export type AmountRange = 'none' | 'low' | 'medium' | 'high'

--- a/tests/checklist.test.ts
+++ b/tests/checklist.test.ts
@@ -241,9 +241,7 @@ describe('ChecklistResult traceability UI', () => {
       totalSelected: SITUATIONS.length,
       selectedSituations: [],
       cardInputMap: {},
-      cardStatusMap: {},
       onCardInputChange: () => undefined,
-      onCardStatusChange: () => undefined,
       onOpenPersonalized: () => undefined,
       onReset: () => undefined,
     }),
@@ -282,9 +280,7 @@ describe('ChecklistResult standard vs itemized filing reminder panel', () => {
         totalSelected: selectedSituations.length,
         selectedSituations,
         cardInputMap: {},
-        cardStatusMap: {},
         onCardInputChange: () => undefined,
-        onCardStatusChange: () => undefined,
         onOpenPersonalized: () => undefined,
         onReset: () => undefined,
       }),
@@ -427,9 +423,7 @@ describe('ChecklistResult export panel', () => {
       totalSelected: SITUATIONS.length,
       selectedSituations: [],
       cardInputMap: {},
-      cardStatusMap: {},
       onCardInputChange: () => undefined,
-      onCardStatusChange: () => undefined,
       onOpenPersonalized: () => undefined,
       onReset: () => undefined,
     }),
@@ -441,9 +435,7 @@ describe('ChecklistResult export panel', () => {
       totalSelected: 0,
       selectedSituations: [],
       cardInputMap: {},
-      cardStatusMap: {},
       onCardInputChange: () => undefined,
-      onCardStatusChange: () => undefined,
       onOpenPersonalized: () => undefined,
       onReset: () => undefined,
     }),
@@ -711,28 +703,27 @@ describe('DeductionCard inline input fields', () => {
   })
 })
 
-// ── DeductionCard status markers ──────────────────────────────────────────────
+// ── DeductionCard badges ─────────────────────────────────────────────────────
 
-describe('DeductionCard status markers (three-state)', () => {
-  it('shows action buttons when status is unset', () => {
+describe('DeductionCard badges', () => {
+  it('does not show the low-risk document preparation badge', () => {
     const html = renderToStaticMarkup(
-      createElement(DeductionCard, { item: makeItem(), status: 'unset', onStatusChange: () => undefined }),
+      createElement(DeductionCard, { item: makeItem({ disclaimer_level: 'low' }) }),
     )
-    expect(html).toContain('確認適用')
-    expect(html).toContain('不適用')
+    expect(html).not.toContain('文件準備')
   })
 
-  it('shows confirmed badge when status is confirmed', () => {
+  it('shows medium-risk badge', () => {
     const html = renderToStaticMarkup(
-      createElement(DeductionCard, { item: makeItem(), status: 'confirmed' }),
+      createElement(DeductionCard, { item: makeItem({ disclaimer_level: 'medium' }) }),
     )
-    expect(html).toContain('確認適用')
+    expect(html).toContain('建議確認')
   })
 
-  it('shows na badge when status is na', () => {
+  it('shows high-risk badge', () => {
     const html = renderToStaticMarkup(
-      createElement(DeductionCard, { item: makeItem(), status: 'na' }),
+      createElement(DeductionCard, { item: makeItem({ disclaimer_level: 'high' }) }),
     )
-    expect(html).toContain('不適用')
+    expect(html).toContain('需進一步確認')
   })
 })

--- a/tests/situation-single-source-flow.test.tsx
+++ b/tests/situation-single-source-flow.test.tsx
@@ -136,6 +136,16 @@ function clickByTestId(testId: string) {
   })
 }
 
+function changeInputByTestId(testId: string, value: string) {
+  const input = container.querySelector<HTMLInputElement>(`[data-testid="${testId}"]`)
+  if (!input) throw new Error(`Missing input with data-testid "${testId}"`)
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  act(() => {
+    valueSetter?.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
 describe('situation single-source flow', () => {
   it('supports grouped situation add modal and synchronized removal', () => {
     renderApp()
@@ -211,11 +221,11 @@ describe('situation single-source flow', () => {
     expect(container.textContent).not.toContain('房屋租金扣除額（需進一步確認）')
   })
 
-  it('shows confirmation when removing a card with existing status', () => {
+  it('shows confirmation when removing a card with existing input', () => {
     renderApp()
     clickButtonByText('租屋居住')
     clickButtonByText('產生節稅清單')
-    clickByTestId('card-status-confirmed-rent-deduction')
+    changeInputByTestId('card-input-rent-deduction-rent_amount', '120000')
 
     clickByTestId('remove-item-rent-deduction')
     expect(container.textContent).toContain('確認移除此項目')


### PR DESCRIPTION
## Summary

第二頁移除以下項目：

label: 文件準備
button: 確認適用、不適用

## Checks

- [x] No personal tax data or private documents included
- [x] Tax-related claims are sourced or marked as draft
- [x] Changes are scoped to this PR
