### PR TITLE
feat(checklist): gross income card, sticky tax summary

### DIFF
--- a/ai-context/04-domain-model.md
+++ b/ai-context/04-domain-model.md
@@ -122,6 +122,19 @@ export type CardInputMap = Record<string, Record<string, string>>
 
 - Outer key: checklist **`item.id`**. Inner key: **`CardInlineField.id`**. Values are **string** (raw input).
 
+### Special encoding: `gross-income`
+
+The `gross-income` item does not use `ITEM_INLINE_FIELDS`; `GrossIncomeCard` manages its own fields:
+
+| fieldId | type | description |
+|---|---|---|
+| `self_income` | `string` (number) | 本人年薪 |
+| `persons_json` | JSON string | Array of `GrossIncomePerson` (excludes self): `[{id, label, income}]` |
+
+`id` values in `persons_json`: `"spouse"` (配偶, filtered by `isMarriedFiling`) and `"extra-N"` (N = 0, 1, …).
+
+Parse / serialize helpers: [`src/lib/grossIncome.ts`](../src/lib/grossIncome.ts) — `parseGrossIncomePersons`, `serializePersonsJson`.
+
 ## Decision tools
 
 ```ts

--- a/ai-context/10-ui-components.md
+++ b/ai-context/10-ui-components.md
@@ -57,7 +57,11 @@ interface Props {
 ```
 
 - Root uses `print-container` for print layout.
-- Embeds `DecisionToolsPanel`, per-category `DeductionCard`s, add-situation modal, remove confirmation dialog, export block (markdown copy/download, `window.print()`).
+- Layout: `max-w-4xl` with `lg:grid lg:grid-cols-[1fr_260px]` — main checklist column left, `TaxSummaryPanel` sticky sidebar right (desktop only; `no-print`).
+- Embeds `DecisionToolsPanel`, per-category cards, add-situation modal, remove confirmation dialog, export block (markdown copy/download, `window.print()`).
+- Card routing: `item.id === 'gross-income'` → renders `GrossIncomeCard`; all others → `DeductionCard`.
+- Computes `grossIncomeTotal` via `useMemo` from `cardInputMap['gross-income']` + `parseGrossIncomePersons` + `calcTotalGrossIncome`.
+- `gross_income` section header shows `grossIncomeTotal` inline when > 0.
 - **`onReset`**: declared on props but **not used** in component body (reserved / dead API until wired).
 - Scroll-to-item: `useEffect` on `scrollToItemId` → [`animateScrollToY`](../src/lib/scrollAnimation.ts) to center card in viewport → `onScrollHandled`.
 - Overlays / tool panel: `no-print` where appropriate.
@@ -79,6 +83,42 @@ interface Props {
 - Wrapper class `print-card`. Remove control `no-print`.
 - Optional inline numeric fields; if `capKey` set, compares parsed amount to `getNumber(capKey)` for green/orange feedback.
 - Collapsible sources `<details>`.
+
+## `GrossIncomeCard.tsx`
+
+```ts
+interface Props {
+  item: ChecklistItem
+  inputValues: Record<string, string>
+  isMarriedFiling: boolean
+  sourceSituationLabels?: string[]
+  removable?: boolean
+  onInputChange: (fieldId: string, value: string) => void
+  onRemove?: () => void
+}
+```
+
+- Specialized card for item `id: 'gross-income'` (category `gross_income`).
+- Multi-person income inputs: self (固定), spouse (when `isMarriedFiling`), extra persons (add/remove).
+- State encoded in two `CardInputMap` fields: `self_income` (string number) and `persons_json` (JSON array of `GrossIncomePerson` excluding self).
+- Add/remove/update person: serializes full array to `persons_json` in a single `onInputChange` call (avoids debounce race).
+- Per-person feedback: shows 薪資所得特別扣除額 and net 薪資所得.
+- Bottom-right result: `綜合所得總額 X,XXX,XXX 元` (or `—` before input).
+- Source situation labels at top (parity with `DeductionCard`), `data-testid="card-source-situations-gross-income"`.
+- Outer div has `print-card` class.
+- Calculation logic: [`src/lib/grossIncome.ts`](../src/lib/grossIncome.ts).
+
+## `TaxSummaryPanel.tsx`
+
+```ts
+interface Props {
+  grossIncome: number | null  // null = no valid input yet
+}
+```
+
+- Sticky right-sidebar panel in `ChecklistResult` (desktop, `lg:sticky lg:top-6`, `no-print`).
+- Currently shows 綜合所得總額 only; structured for future extension (other deduction totals, tax calculation).
+- Displays `—` when `grossIncome` is null.
 
 ## `DecisionToolsPanel.tsx`
 

--- a/src/components/ChecklistResult.tsx
+++ b/src/components/ChecklistResult.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type {
   CardInputMap,
   Situation,
@@ -9,8 +9,11 @@ import { formatChecklistMarkdown } from '../lib/exportChecklist'
 import { getNumber } from '../lib/numbers'
 import { animateScrollToY } from '../lib/scrollAnimation'
 import { ITEM_INLINE_FIELDS } from '../content/inlineFields'
+import { parseGrossIncomePersons, calcTotalGrossIncome } from '../lib/grossIncome'
 import { DecisionToolsPanel } from './DecisionToolsPanel'
 import { DeductionCard } from './DeductionCard'
+import { GrossIncomeCard } from './GrossIncomeCard'
+import { TaxSummaryPanel } from './TaxSummaryPanel'
 
 export interface RemovalImpactPreview {
   itemId: string
@@ -447,8 +450,16 @@ export function ChecklistResult({
     setIsAddModalOpen(false)
   }
 
+  const isMarriedFiling = selectedSituations.includes('married')
+
+  const grossIncomeTotal = useMemo(() => {
+    const inputs = cardInputMap['gross-income'] ?? {}
+    const persons = parseGrossIncomePersons(inputs, isMarriedFiling)
+    return calcTotalGrossIncome(persons)
+  }, [cardInputMap, isMarriedFiling])
+
   return (
-    <div className="mx-auto max-w-2xl px-4 py-8 print-container">
+    <div className="mx-auto max-w-4xl px-4 py-8 print-container">
       <AddSituationModal
         groups={addableSituationGroups}
         isOpen={isAddModalOpen}
@@ -465,94 +476,123 @@ export function ChecklistResult({
         />
       )}
 
-      <div className="mb-1 flex items-center justify-between gap-3">
-        <h1 className="text-xl font-semibold text-gray-900">節稅清單</h1>
-        <button
-          type="button"
-          onClick={openAddModal}
-          disabled={!canAddMore}
-          data-testid="open-add-situation-modal-btn"
-          className={[
-            'inline-flex items-center gap-1 rounded border px-3 py-1.5 text-xs font-medium transition-colors',
-            canAddMore
-              ? 'border-blue-300 bg-blue-50 text-blue-800 hover:bg-blue-100'
-              : 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-300',
-          ].join(' ')}
-        >
-          <span aria-hidden="true">+</span>
-          <span>新增項目</span>
-        </button>
-      </div>
-      <p className="mb-4 text-sm text-gray-500">
-        根據您選擇的 {totalSelected} 項情況，找到 {totalItems} 個值得確認的項目。
-      </p>
+      <div className="lg:grid lg:grid-cols-[1fr_260px] lg:gap-6 lg:items-start">
+        {/* ── Main column ── */}
+        <div>
+          <div className="mb-1 flex items-center justify-between gap-3">
+            <h1 className="text-xl font-semibold text-gray-900">節稅清單</h1>
+            <button
+              type="button"
+              onClick={openAddModal}
+              disabled={!canAddMore}
+              data-testid="open-add-situation-modal-btn"
+              className={[
+                'inline-flex items-center gap-1 rounded border px-3 py-1.5 text-xs font-medium transition-colors',
+                canAddMore
+                  ? 'border-blue-300 bg-blue-50 text-blue-800 hover:bg-blue-100'
+                  : 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-300',
+              ].join(' ')}
+            >
+              <span aria-hidden="true">+</span>
+              <span>新增項目</span>
+            </button>
+          </div>
+          <p className="mb-4 text-sm text-gray-500">
+            根據您選擇的 {totalSelected} 項情況，找到 {totalItems} 個值得確認的項目。
+          </p>
 
-      <div className="mb-6 no-print">
-        <DecisionToolsPanel selectedSituations={selectedSituations} />
-      </div>
+          <div className="mb-6 no-print">
+            <DecisionToolsPanel selectedSituations={selectedSituations} />
+          </div>
 
-      {!hasResults && (
-        <div className="py-12 text-center text-gray-400">
-          <p>目前清單中沒有項目</p>
-          <p className="mt-2 text-xs text-gray-400">可使用右上角「新增項目」加入要確認的情境</p>
-        </div>
-      )}
-
-      <div className="space-y-8">
-        {groups.map((group) => (
-          <section
-            key={group.category}
-            ref={(element) => {
-              sectionRefs.current[group.category] = element
-            }}
-            data-testid={`checklist-section-${group.category}`}
-          >
-            <h2 className="mb-3 border-b border-gray-200 pb-1 text-base font-semibold text-gray-700">
-              {group.label}
-            </h2>
-            {group.category === 'general_deductions' && (
-              <StandardItemizedEducationPanel groups={groups} selectedSituations={selectedSituations} />
-            )}
-            <div className="space-y-3">
-              {group.items.map((item) => (
-                <div
-                  key={item.id}
-                  ref={(element) => {
-                    itemRefs.current[item.id] = element
-                  }}
-                  data-testid={`checklist-item-${item.id}`}
-                >
-                  <DeductionCard
-                    item={item}
-                    inlineFields={ITEM_INLINE_FIELDS[item.id] ?? []}
-                    inputValues={cardInputMap[item.id] ?? {}}
-                    sourceSituationLabels={itemSourceSituationLabelsById[item.id] ?? []}
-                    removable
-                    onInputChange={(fieldId, value) => onCardInputChange(item.id, fieldId, value)}
-                    onRemove={() => onRemoveItem?.(item.id)}
-                  />
-                </div>
-              ))}
+          {!hasResults && (
+            <div className="py-12 text-center text-gray-400">
+              <p>目前清單中沒有項目</p>
+              <p className="mt-2 text-xs text-gray-400">可使用右上角「新增項目」加入要確認的情境</p>
             </div>
-          </section>
-        ))}
-      </div>
+          )}
 
-      <div className="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-4">
-        <p className="text-xs leading-relaxed text-gray-500">
-          <strong className="text-gray-700">使用提醒：</strong>
-          本清單協助整理可能適用的申報項目，根據114年度相關法規與官方資料整理。
-          正式申報結果及稅負計算請以財政部電子申報系統為準，並視個人情況向稅務機關或記帳士確認。
-          標示「需進一步確認」的項目因規定複雜或有排富條款，建議諮詢後再決定是否申報。
-        </p>
-      </div>
+          <div className="space-y-8">
+            {groups.map((group) => (
+              <section
+                key={group.category}
+                ref={(element) => {
+                  sectionRefs.current[group.category] = element
+                }}
+                data-testid={`checklist-section-${group.category}`}
+              >
+                <h2 className="mb-3 border-b border-gray-200 pb-1 text-base font-semibold text-gray-700 flex items-baseline gap-2">
+                  <span>{group.label}</span>
+                  {group.category === 'gross_income' && grossIncomeTotal > 0 && (
+                    <span className="text-sm font-semibold text-green-700 tabular-nums">
+                      {grossIncomeTotal.toLocaleString('zh-TW')} 元
+                    </span>
+                  )}
+                </h2>
+                {group.category === 'general_deductions' && (
+                  <StandardItemizedEducationPanel groups={groups} selectedSituations={selectedSituations} />
+                )}
+                <div className="space-y-3">
+                  {group.items.map((item) => (
+                    <div
+                      key={item.id}
+                      ref={(element) => {
+                        itemRefs.current[item.id] = element
+                      }}
+                      data-testid={`checklist-item-${item.id}`}
+                    >
+                      {item.id === 'gross-income' ? (
+                        <GrossIncomeCard
+                          item={item}
+                          inputValues={cardInputMap[item.id] ?? {}}
+                          isMarriedFiling={isMarriedFiling}
+                          sourceSituationLabels={itemSourceSituationLabelsById[item.id] ?? []}
+                          removable
+                          onInputChange={(fieldId, value) => onCardInputChange(item.id, fieldId, value)}
+                          onRemove={() => onRemoveItem?.(item.id)}
+                        />
+                      ) : (
+                        <DeductionCard
+                          item={item}
+                          inlineFields={ITEM_INLINE_FIELDS[item.id] ?? []}
+                          inputValues={cardInputMap[item.id] ?? {}}
+                          sourceSituationLabels={itemSourceSituationLabelsById[item.id] ?? []}
+                          removable
+                          onInputChange={(fieldId, value) => onCardInputChange(item.id, fieldId, value)}
+                          onRemove={() => onRemoveItem?.(item.id)}
+                        />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
 
-      {hasResults && (
-        <ExportPanel
-          groups={groups}
-          totalSelected={totalSelected}
-        />
-      )}
+          <div className="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-4">
+            <p className="text-xs leading-relaxed text-gray-500">
+              <strong className="text-gray-700">使用提醒：</strong>
+              本清單協助整理可能適用的申報項目，根據114年度相關法規與官方資料整理。
+              正式申報結果及稅負計算請以財政部電子申報系統為準，並視個人情況向稅務機關或記帳士確認。
+              標示「需進一步確認」的項目因規定複雜或有排富條款，建議諮詢後再決定是否申報。
+            </p>
+          </div>
+
+          {hasResults && (
+            <ExportPanel
+              groups={groups}
+              totalSelected={totalSelected}
+            />
+          )}
+        </div>
+
+        {/* ── Sidebar ── */}
+        <aside className="no-print mt-6 lg:mt-0 lg:sticky lg:top-6">
+          <TaxSummaryPanel
+            grossIncome={grossIncomeTotal > 0 ? grossIncomeTotal : null}
+          />
+        </aside>
+      </div>
     </div>
   )
 }

--- a/src/components/GrossIncomeCard.tsx
+++ b/src/components/GrossIncomeCard.tsx
@@ -1,0 +1,304 @@
+import type { ChecklistItem } from '../types/content'
+import {
+  getSalaryDeductionCap,
+  calcPersonDeduction,
+  calcPersonNetIncome,
+  calcTotalGrossIncome,
+  parseGrossIncomePersons,
+  serializePersonsJson,
+  type GrossIncomePerson,
+} from '../lib/grossIncome'
+
+interface Props {
+  item: ChecklistItem
+  inputValues: Record<string, string>
+  isMarriedFiling: boolean
+  sourceSituationLabels?: string[]
+  removable?: boolean
+  onInputChange: (fieldId: string, value: string) => void
+  onRemove?: () => void
+}
+
+function formatTwd(n: number) {
+  return n.toLocaleString('zh-TW')
+}
+
+function parseRawIncome(raw: string): number {
+  if (!raw || raw.trim() === '') return 0
+  const n = Number(raw.replace(/,/g, ''))
+  return isNaN(n) || n < 0 ? 0 : n
+}
+
+interface PersonRowProps {
+  person: GrossIncomePerson
+  incomeRaw: string       // the string value being edited
+  isFixed: boolean        // 本人 or 配偶 — cannot be deleted or relabeled
+  onIncomeChange: (value: string) => void
+  onLabelChange?: (value: string) => void
+  onRemove?: () => void
+}
+
+function PersonRow({ person, incomeRaw, isFixed, onIncomeChange, onLabelChange, onRemove }: PersonRowProps) {
+  const cap = getSalaryDeductionCap()
+  const income = parseRawIncome(incomeRaw)
+  const deduction = calcPersonDeduction(income)
+  const net = calcPersonNetIncome(income)
+  const hasIncome = income > 0
+
+  return (
+    <div className="border-b border-blue-100 last:border-0 py-3 first:pt-0 last:pb-0">
+      <div className="flex items-center gap-2 mb-1.5">
+        {isFixed ? (
+          <span className="text-xs font-semibold text-gray-700 min-w-[3rem]">{person.label}</span>
+        ) : (
+          <input
+            type="text"
+            value={person.label}
+            onChange={(e) => onLabelChange?.(e.target.value)}
+            placeholder="稱謂（如：父親）"
+            data-testid={`gross-income-label-${person.id}`}
+            className="text-xs font-semibold text-gray-700 border border-gray-200 rounded px-1.5 py-0.5 w-28 focus:border-blue-400 focus:outline-none"
+          />
+        )}
+        {!isFixed && onRemove && (
+          <button
+            type="button"
+            onClick={onRemove}
+            aria-label={`移除 ${person.label || '此人員'}`}
+            className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded-full border border-gray-200 text-xs text-gray-400 hover:border-red-300 hover:bg-red-50 hover:text-red-500 transition-colors"
+          >
+            ×
+          </button>
+        )}
+      </div>
+      <label className="mt-1 block text-xs text-gray-500">
+        薪資收入
+      </label>
+      <div className="flex items-center gap-1.5">
+        <input
+          type="number"
+          min="0"
+          value={incomeRaw}
+          onChange={(e) => onIncomeChange(e.target.value)}
+          placeholder="輸入金額"
+          data-testid={`gross-income-input-${person.id}`}
+          className="w-40 rounded border border-gray-300 px-2 py-1 text-xs text-gray-800 focus:border-blue-400 focus:outline-none"
+        />
+        <span className="text-xs text-gray-500">元</span>
+      </div>
+      {hasIncome && (
+        <p className="mt-1.5 text-xs text-gray-500">
+          {'綜合所得 ＝ 薪資收入 − 薪資所得特別扣除額 ＝ '}
+          <span className="font-medium text-gray-700">{formatTwd(income)} 元</span>
+          {' − '}
+          <span className="font-medium text-indigo-700">{formatTwd(deduction)} 元</span>
+          {income <= cap && <span className="text-gray-400">（全額扣除）</span>}
+          {' ＝ '}
+          <span className={`font-medium ${net > 0 ? 'text-gray-800' : 'text-green-700'}`}>
+            {formatTwd(net)} 元
+          </span>
+        </p>
+      )}
+    </div>
+  )
+}
+
+export function GrossIncomeCard({
+  item,
+  inputValues,
+  isMarriedFiling,
+  sourceSituationLabels = [],
+  removable = false,
+  onInputChange,
+  onRemove,
+}: Props) {
+  const persons = parseGrossIncomePersons(inputValues, isMarriedFiling)
+  const total = calcTotalGrossIncome(persons)
+  const hasAnyIncome = persons.some((p) => p.income > 0)
+
+  // Persons stored in persons_json: everyone except self
+  const personsInJson = persons.filter((p) => p.id !== 'self')
+
+  function updatePersonsJson(next: GrossIncomePerson[]) {
+    onInputChange('persons_json', serializePersonsJson(next))
+  }
+
+  function handleSelfIncomeChange(value: string) {
+    onInputChange('self_income', value)
+  }
+
+  function handlePersonIncomeChange(targetId: string, value: string) {
+    const next = personsInJson.map((p) =>
+      p.id === targetId ? { ...p, income: Number(value.replace(/,/g, '')) || 0 } : p,
+    )
+    updatePersonsJson(next)
+  }
+
+  function handlePersonLabelChange(targetId: string, value: string) {
+    const next = personsInJson.map((p) =>
+      p.id === targetId ? { ...p, label: value } : p,
+    )
+    updatePersonsJson(next)
+  }
+
+  function handleRemovePerson(targetId: string) {
+    const next = personsInJson.filter((p) => p.id !== targetId)
+    updatePersonsJson(next)
+  }
+
+  function handleAddPerson() {
+    const extraNums = personsInJson
+      .filter((p) => p.id.startsWith('extra-'))
+      .map((p) => parseInt(p.id.slice('extra-'.length), 10))
+      .filter((n) => Number.isFinite(n))
+    const nextId = extraNums.length > 0 ? Math.max(...extraNums) + 1 : 0
+    const next = [...personsInJson, { id: `extra-${nextId}`, label: '', income: 0 }]
+    updatePersonsJson(next)
+  }
+
+  const selfPerson = persons.find((p) => p.id === 'self')!
+  const selfRaw = inputValues['self_income'] ?? ''
+
+  return (
+    <div className="border border-gray-200 rounded-lg p-4 bg-white print-card" data-testid={`checklist-card-${item.id}`}>
+      {/* Header */}
+      <div className="flex items-start gap-2 mb-2">
+        <h3 className="font-medium text-gray-900 flex-1 text-sm">{item.title}</h3>
+        {removable && onRemove && (
+          <button
+            type="button"
+            onClick={onRemove}
+            aria-label={`移除項目：${item.title}`}
+            data-testid={`remove-item-${item.id}`}
+            className="no-print inline-flex h-6 w-6 items-center justify-center rounded-full border border-gray-200 text-sm text-gray-500 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+          >
+            ×
+          </button>
+        )}
+      </div>
+
+      <p className="text-sm text-gray-700 mb-3">{item.why_it_matters}</p>
+
+      {sourceSituationLabels.length > 0 && (
+        <p
+          className="mb-3 text-xs text-indigo-700"
+          data-testid={`card-source-situations-${item.id}`}
+          title={`情境：${sourceSituationLabels.join('、')}`}
+        >
+          情境：{sourceSituationLabels.slice(0, 2).join('、')}
+          {sourceSituationLabels.length > 2 ? ` +${sourceSituationLabels.length - 2}` : ''}
+        </p>
+      )}
+
+      {/* Person rows */}
+      <div className="rounded border border-blue-100 bg-blue-50/40 p-3 space-y-0">
+        {/* Self row */}
+        <PersonRow
+          person={selfPerson}
+          incomeRaw={selfRaw}
+          isFixed
+          onIncomeChange={handleSelfIncomeChange}
+        />
+
+        {/* Other persons (spouse + extras) from persons_json */}
+        {personsInJson.map((person) => {
+          const isFixed = person.id === 'spouse'
+          const incomeRaw = String(person.income === 0 && !inputValues['persons_json'] ? '' : person.income || '')
+          return (
+            <PersonRow
+              key={person.id}
+              person={person}
+              incomeRaw={incomeRaw === '0' ? '' : incomeRaw}
+              isFixed={isFixed}
+              onIncomeChange={(val) => handlePersonIncomeChange(person.id, val)}
+              onLabelChange={isFixed ? undefined : (val) => handlePersonLabelChange(person.id, val)}
+              onRemove={isFixed ? undefined : () => handleRemovePerson(person.id)}
+            />
+          )
+        })}
+      </div>
+
+      {/* Add person button */}
+      <button
+        type="button"
+        onClick={handleAddPerson}
+        className="no-print mt-2 flex items-center gap-1 text-xs text-blue-600 hover:text-blue-800 transition-colors"
+        data-testid="gross-income-add-person"
+      >
+        <span aria-hidden="true">＋</span>
+        <span>新增受扶養親屬</span>
+      </button>
+
+      {/* Privacy notice */}
+      <p className="mt-2 text-xs text-gray-400">
+        資料僅在您的瀏覽器處理，不會傳送至任何伺服器
+      </p>
+
+      {/* Result */}
+      <div className="mt-3 border-t border-gray-100 pt-3">
+        <div className="text-xs text-gray-500 space-y-0.5">
+          <p className="font-medium text-gray-700">綜合所得總額</p>
+          {hasAnyIncome ? (
+            <>
+              {persons
+                .filter((p) => p.income > 0)
+                .map((p, i) => (
+                  <div key={p.id} className="flex justify-between gap-4">
+                    <span>{i === 0 ? <span className="invisible">＋</span> : '＋'} {p.label}</span>
+                    <span className="tabular-nums">{formatTwd(calcPersonNetIncome(p.income))} 元</span>
+                  </div>
+                ))}
+              <div className="flex justify-between gap-4 font-semibold text-green-700 border-t border-gray-100 pt-0.5 mt-0.5" data-testid="gross-income-total">
+                <span>＝</span>
+                <span className="tabular-nums">{formatTwd(total)} 元</span>
+              </div>
+            </>
+          ) : (
+            <p className="font-semibold text-gray-300" data-testid="gross-income-total">—</p>
+          )}
+        </div>
+      </div>
+
+      {/* Source refs */}
+      <div className="mt-3">
+        <details className="group">
+          <summary className="cursor-pointer select-none text-xs font-medium text-gray-500 hover:text-gray-700">
+            來源與官方參考
+          </summary>
+          <ul className="mt-2 space-y-1">
+            {item.source_refs.map((ref) => (
+              <li key={ref.source_id} className="text-xs text-gray-500">
+                {ref.url ? (
+                  <a
+                    href={ref.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-gray-600 underline underline-offset-2 hover:text-gray-800"
+                  >
+                    {ref.label}
+                  </a>
+                ) : (
+                  <span className="text-gray-600">{ref.label}</span>
+                )}
+                {ref.authority && <span className="text-gray-400"> · {ref.authority}</span>}
+              </li>
+            ))}
+          </ul>
+        </details>
+      </div>
+
+      {/* Notes */}
+      <div className="mt-3">
+        <details className="group">
+          <summary className="cursor-pointer select-none text-xs font-medium text-gray-500 hover:text-gray-700">
+            注意事項
+          </summary>
+          <div className="mt-2 space-y-1.5 text-xs text-gray-500">
+            <p>納稅義務人、配偶或申報受扶養親屬有「薪資收入」者，應分別就「薪資所得特別扣除額」或「必要費用」2擇1減除，減除後的餘額為薪資所得。</p>
+            <p>本網站簡化此流程，統一採用「薪資所得特別扣除額」計算，還請海涵！</p>
+          </div>
+        </details>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TaxSummaryPanel.tsx
+++ b/src/components/TaxSummaryPanel.tsx
@@ -1,0 +1,38 @@
+interface Props {
+  grossIncome: number | null  // null = no valid input yet
+}
+
+function formatTwd(n: number) {
+  return n.toLocaleString('zh-TW')
+}
+
+export function TaxSummaryPanel({ grossIncome }: Props) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
+      <div className="border-b border-gray-100 px-4 py-3">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+          節稅試算摘要
+        </h3>
+      </div>
+
+      <div className="px-4 py-3 space-y-2">
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="text-xs text-gray-500 shrink-0">綜合所得總額</span>
+          {grossIncome !== null ? (
+            <span className="text-sm font-semibold text-gray-900 tabular-nums">
+              {formatTwd(grossIncome)} 元
+            </span>
+          ) : (
+            <span className="text-sm font-medium text-gray-300">—</span>
+          )}
+        </div>
+      </div>
+
+      <div className="border-t border-gray-50 bg-gray-50 px-4 py-2">
+        <p className="text-xs text-gray-400 leading-relaxed">
+          填入各項金額後，此處將顯示試算結果
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/content/deductions.ts
+++ b/src/content/deductions.ts
@@ -176,26 +176,26 @@ export const CHECKLIST_ITEMS: ChecklistItem[] = [
     next_action: '向銀行申請年度貸款利息繳納證明',
   },
 
-  // ── Special deductions (特別) ──────────────────────────────────────────────
+  // ── Gross income (綜合所得總額) ─────────────────────────────────────────────
   {
-    id: 'salary-special-deduction',
-    title: '薪資所得特別扣除額',
+    id: 'gross-income',
+    title: '綜合所得總額',
     category: 'gross_income',
     situations: ['salary_income'],
-    why_it_matters: `有薪資所得即可每人扣除 ${n('special_deduction_salary')} 元，夫妻各自計算，無需憑證`,
+    why_it_matters: `填入去年（114年1月至12月）本人與親屬**薪資收入**。\n系統自動套用「薪資所得特別扣除額」（每人最多 ${n('special_deduction_salary')} 元），計算出綜合所得總額。`,
     eligibility_cues: [
-      '有薪資所得的納稅義務人與配偶各自適用',
-      '無其他資格限制',
+      '有薪資收入的納稅義務人、配偶及申報受扶養親屬均需申報',
+      '薪資所得特別扣除額每人最高 218,000 元，不超過實際薪資收入',
     ],
     documents_to_prepare: [],
     limitations: [
-      '扣除額不超過實際薪資所得金額',
-      '申報系統通常自動帶入，請確認金額正確',
+      '本試算以薪資所得為範圍；如有利息、租賃、執行業務等其他所得，需另行申報',
+      '申報系統通常自動帶入薪資資料，請確認金額正確',
     ],
     source_refs: [SRC_ITA, SRC_MANUAL],
     verification_status: 'verified',
     disclaimer_level: 'low',
-    next_action: '確認申報書薪資所得欄位及特別扣除額已正確帶入',
+    next_action: '確認申報書薪資所得欄位與薪資所得特別扣除額已正確帶入',
   },
   {
     id: 'savings-investment-deduction',

--- a/src/content/deductions.ts
+++ b/src/content/deductions.ts
@@ -182,14 +182,13 @@ export const CHECKLIST_ITEMS: ChecklistItem[] = [
     title: '綜合所得總額',
     category: 'gross_income',
     situations: ['salary_income'],
-    why_it_matters: `填入去年（114年1月至12月）本人與親屬**薪資收入**。\n系統自動套用「薪資所得特別扣除額」（每人最多 ${n('special_deduction_salary')} 元），計算出綜合所得總額。`,
+    why_it_matters: `填入去年（114年1月至12月）本人與親屬的「薪資收入」。系統自動套用「薪資所得特別扣除額」（每人最多 ${n('special_deduction_salary')} 元），計算出綜合所得總額。`,
     eligibility_cues: [
       '有薪資收入的納稅義務人、配偶及申報受扶養親屬均需申報',
-      '薪資所得特別扣除額每人最高 218,000 元，不超過實際薪資收入',
+      `薪資所得特別扣除額每人最高 ${n('special_deduction_salary')} 元，不超過實際薪資收入`,
     ],
     documents_to_prepare: [],
     limitations: [
-      '本試算以薪資所得為範圍；如有利息、租賃、執行業務等其他所得，需另行申報',
       '申報系統通常自動帶入薪資資料，請確認金額正確',
     ],
     source_refs: [SRC_ITA, SRC_MANUAL],

--- a/src/content/inlineFields.ts
+++ b/src/content/inlineFields.ts
@@ -37,13 +37,4 @@ export const ITEM_INLINE_FIELDS: Record<string, CardInlineField[]> = {
       capKey: null,
     },
   ],
-  'salary-special-deduction': [
-    {
-      id: 'salary_amount',
-      label: '今年薪資所得總額',
-      type: 'number',
-      unit: '元',
-      capKey: 'special_deduction_salary',
-    },
-  ],
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,20 @@
 @import "tailwindcss";
 
+/*
+  Prevent iOS Safari from auto-zooming when tapping inputs.
+  font-size must be >= 16px to suppress the behavior.
+  Written outside @layer so it overrides Tailwind's text-xs utility.
+*/
+input[type="text"],
+input[type="number"],
+input[type="email"],
+input[type="search"],
+input[type="tel"],
+select,
+textarea {
+  font-size: 16px;
+}
+
 @media print {
   @page {
     size: A4;

--- a/src/lib/grossIncome.ts
+++ b/src/lib/grossIncome.ts
@@ -1,0 +1,80 @@
+import { getNumber } from './numbers'
+
+export interface GrossIncomePerson {
+  id: string    // 'self' | 'spouse' | 'extra-0' | 'extra-1' | ...
+  label: string
+  income: number
+}
+
+const SALARY_DEDUCTION_CAP_KEY = 'special_deduction_salary'
+
+export function getSalaryDeductionCap(): number {
+  return getNumber(SALARY_DEDUCTION_CAP_KEY)
+}
+
+export function calcPersonDeduction(income: number): number {
+  return Math.min(income, getSalaryDeductionCap())
+}
+
+export function calcPersonNetIncome(income: number): number {
+  return Math.max(0, income - calcPersonDeduction(income))
+}
+
+function parseIncome(raw: string | undefined): number {
+  if (!raw || raw.trim() === '') return 0
+  const n = Number(raw.replace(/,/g, ''))
+  return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+// Deserialize the persons_json field (excludes self)
+function parsePersonsJson(raw: string | undefined): GrossIncomePerson[] {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed
+      .filter((p): p is GrossIncomePerson =>
+        p && typeof p.id === 'string' && typeof p.label === 'string' && typeof p.income === 'number',
+      )
+      .map((p) => ({ ...p, income: Number.isFinite(p.income) && p.income > 0 ? p.income : 0 }))
+  } catch {
+    return []
+  }
+}
+
+// Serialize non-self persons back to persons_json value
+export function serializePersonsJson(persons: GrossIncomePerson[]): string {
+  return JSON.stringify(persons)
+}
+
+// Build the full persons list from CardInputMap fields
+export function parseGrossIncomePersons(
+  inputValues: Record<string, string>,
+  isMarriedFiling: boolean,
+): GrossIncomePerson[] {
+  const personsFromJson = parsePersonsJson(inputValues['persons_json'])
+
+  const self: GrossIncomePerson = {
+    id: 'self',
+    label: '本人',
+    income: parseIncome(inputValues['self_income']),
+  }
+
+  // Spouse comes from persons_json if married; ensure it's present
+  const hasSpouseInJson = personsFromJson.some((p) => p.id === 'spouse')
+  let others = personsFromJson
+
+  if (isMarriedFiling && !hasSpouseInJson) {
+    // Auto-insert spouse at the front if not yet in json
+    others = [{ id: 'spouse', label: '配偶', income: 0 }, ...others]
+  } else if (!isMarriedFiling) {
+    // Filter out spouse when not filing jointly
+    others = others.filter((p) => p.id !== 'spouse')
+  }
+
+  return [self, ...others]
+}
+
+export function calcTotalGrossIncome(persons: GrossIncomePerson[]): number {
+  return persons.reduce((sum, p) => sum + calcPersonNetIncome(p.income), 0)
+}

--- a/tests/checklist.test.ts
+++ b/tests/checklist.test.ts
@@ -64,7 +64,7 @@ describe('filterBySituations', () => {
     const ids = items.map((i) => i.id)
     expect(ids).toContain('exemption-general')
     expect(ids).toContain('standard-deduction-single')
-    expect(ids).toContain('salary-special-deduction')
+    expect(ids).toContain('gross-income')
   })
 
   it('married returns married standard deduction', () => {
@@ -187,7 +187,7 @@ describe('groupByCategory', () => {
     const groups = groupByCategory(filterBySituations(published, ['salary_income']))
     const gross = groups.find((g) => g.category === 'gross_income')
     expect(gross?.label).toBe('綜合所得總額')
-    expect(gross?.items.map((i) => i.id)).toContain('salary-special-deduction')
+    expect(gross?.items.map((i) => i.id)).toContain('gross-income')
   })
 
   it('each group has a human-readable label', () => {
@@ -455,8 +455,8 @@ describe('annual number sourcing', () => {
     expect(item?.why_it_matters).toContain('270,000')
   })
 
-  it('salary-special-deduction why_it_matters contains 218,000', () => {
-    const item = CHECKLIST_ITEMS.find((i) => i.id === 'salary-special-deduction')
+  it('gross-income why_it_matters contains 218,000', () => {
+    const item = CHECKLIST_ITEMS.find((i) => i.id === 'gross-income')
     expect(item?.why_it_matters).toContain('218,000')
   })
 

--- a/tests/grossIncome.test.ts
+++ b/tests/grossIncome.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getSalaryDeductionCap,
+  calcPersonDeduction,
+  calcPersonNetIncome,
+  parseGrossIncomePersons,
+  serializePersonsJson,
+  calcTotalGrossIncome,
+} from '../src/lib/grossIncome'
+
+describe('getSalaryDeductionCap', () => {
+  it('returns 218000', () => {
+    expect(getSalaryDeductionCap()).toBe(218_000)
+  })
+})
+
+describe('calcPersonDeduction', () => {
+  it('returns income when below cap', () => {
+    expect(calcPersonDeduction(100_000)).toBe(100_000)
+  })
+
+  it('returns cap when income equals cap', () => {
+    expect(calcPersonDeduction(218_000)).toBe(218_000)
+  })
+
+  it('returns cap when income exceeds cap', () => {
+    expect(calcPersonDeduction(500_000)).toBe(218_000)
+  })
+
+  it('returns 0 for 0 income', () => {
+    expect(calcPersonDeduction(0)).toBe(0)
+  })
+})
+
+describe('calcPersonNetIncome', () => {
+  it('returns 0 when income below cap (fully deducted)', () => {
+    expect(calcPersonNetIncome(150_000)).toBe(0)
+  })
+
+  it('returns 0 when income equals cap', () => {
+    expect(calcPersonNetIncome(218_000)).toBe(0)
+  })
+
+  it('returns excess over cap', () => {
+    expect(calcPersonNetIncome(800_000)).toBe(582_000)
+  })
+
+  it('returns 0 for 0 income', () => {
+    expect(calcPersonNetIncome(0)).toBe(0)
+  })
+})
+
+describe('parseGrossIncomePersons', () => {
+  it('always includes self with income from self_income', () => {
+    const result = parseGrossIncomePersons({ self_income: '500000' }, false)
+    expect(result[0]).toMatchObject({ id: 'self', label: '本人', income: 500_000 })
+  })
+
+  it('self income defaults to 0 if missing', () => {
+    const result = parseGrossIncomePersons({}, false)
+    expect(result[0].income).toBe(0)
+  })
+
+  it('self income defaults to 0 for empty string', () => {
+    const result = parseGrossIncomePersons({ self_income: '' }, false)
+    expect(result[0].income).toBe(0)
+  })
+
+  it('self income defaults to 0 for invalid string', () => {
+    const result = parseGrossIncomePersons({ self_income: 'abc' }, false)
+    expect(result[0].income).toBe(0)
+  })
+
+  it('self income clamps negative to 0', () => {
+    const result = parseGrossIncomePersons({ self_income: '-1000' }, false)
+    expect(result[0].income).toBe(0)
+  })
+
+  it('adds spouse when isMarriedFiling=true and persons_json is empty', () => {
+    const result = parseGrossIncomePersons({ self_income: '500000' }, true)
+    expect(result).toHaveLength(2)
+    expect(result[1]).toMatchObject({ id: 'spouse', label: '配偶', income: 0 })
+  })
+
+  it('does not duplicate spouse when already in persons_json', () => {
+    const json = serializePersonsJson([{ id: 'spouse', label: '配偶', income: 300_000 }])
+    const result = parseGrossIncomePersons({ persons_json: json }, true)
+    const spouseEntries = result.filter((p) => p.id === 'spouse')
+    expect(spouseEntries).toHaveLength(1)
+    expect(spouseEntries[0].income).toBe(300_000)
+  })
+
+  it('filters out spouse when isMarriedFiling=false', () => {
+    const json = serializePersonsJson([{ id: 'spouse', label: '配偶', income: 300_000 }])
+    const result = parseGrossIncomePersons({ persons_json: json }, false)
+    expect(result.every((p) => p.id !== 'spouse')).toBe(true)
+  })
+
+  it('includes extra persons from persons_json', () => {
+    const json = serializePersonsJson([
+      { id: 'extra-0', label: '父親', income: 100_000 },
+    ])
+    const result = parseGrossIncomePersons({ self_income: '500000', persons_json: json }, false)
+    expect(result).toHaveLength(2)
+    expect(result[1]).toMatchObject({ id: 'extra-0', label: '父親', income: 100_000 })
+  })
+
+  it('handles malformed persons_json gracefully', () => {
+    const result = parseGrossIncomePersons({ persons_json: 'not-json' }, false)
+    expect(result).toHaveLength(1) // only self
+  })
+})
+
+describe('serializePersonsJson round-trip', () => {
+  it('round-trips correctly', () => {
+    const persons = [
+      { id: 'spouse', label: '配偶', income: 300_000 },
+      { id: 'extra-0', label: '父親', income: 100_000 },
+    ]
+    const json = serializePersonsJson(persons)
+    const parsed = parseGrossIncomePersons(
+      { self_income: '500000', persons_json: json },
+      true,
+    )
+    expect(parsed[1]).toMatchObject({ id: 'spouse', income: 300_000 })
+    expect(parsed[2]).toMatchObject({ id: 'extra-0', label: '父親', income: 100_000 })
+  })
+})
+
+describe('calcTotalGrossIncome', () => {
+  it('sums net incomes of all persons', () => {
+    const persons = [
+      { id: 'self', label: '本人', income: 800_000 },
+      { id: 'spouse', label: '配偶', income: 300_000 },
+      { id: 'extra-0', label: '父親', income: 100_000 },
+    ]
+    // 800k - 218k = 582k; 300k - 218k = 82k; 100k fully deducted = 0
+    expect(calcTotalGrossIncome(persons)).toBe(582_000 + 82_000 + 0)
+  })
+
+  it('returns 0 when all incomes are at or below cap', () => {
+    const persons = [
+      { id: 'self', label: '本人', income: 218_000 },
+      { id: 'spouse', label: '配偶', income: 150_000 },
+    ]
+    expect(calcTotalGrossIncome(persons)).toBe(0)
+  })
+
+  it('returns 0 for empty persons list', () => {
+    expect(calcTotalGrossIncome([])).toBe(0)
+  })
+})

--- a/tests/situation-single-source-flow.test.tsx
+++ b/tests/situation-single-source-flow.test.tsx
@@ -196,7 +196,7 @@ describe('situation single-source flow', () => {
     expect(multiSource?.textContent).toContain('情境：薪資收入、股利收入')
     expect(multiSource?.textContent).not.toContain('來源')
 
-    const singleSource = container.querySelector<HTMLElement>('[data-testid="card-source-situations-salary-special-deduction"]')
+    const singleSource = container.querySelector<HTMLElement>('[data-testid="card-source-situations-gross-income"]')
     expect(singleSource?.textContent).toContain('情境：薪資收入')
   })
 


### PR DESCRIPTION
## Summary

- Add GrossIncomeCard for item gross-income (self/spouse/extra persons, persons_json + self_income encoding)
- Add TaxSummaryPanel (desktop sticky sidebar) showing total gross income
- Widen ChecklistResult layout (max-w-4xl) with lg two-column grid
- Introduce grossIncome.ts: parse/serialize persons, calc total gross income
- Route gross-income to GrossIncomeCard; adjust deductions/inline fields
- Tests for gross income; update checklist and situation flow tests
- Document gross-income cardInputMap encoding in ai-context

## Checks

- [x] No personal tax data or private documents included
- [x] Tax-related claims are sourced or marked as draft
- [x] Changes are scoped to this PR
