### PR TITLE
refactor(checklist): drop further_check category; fold items into gross income

### DIFF
--- a/ai-context/04-domain-model.md
+++ b/ai-context/04-domain-model.md
@@ -10,7 +10,7 @@ export type DisclaimerLevel = 'low' | 'medium' | 'high'
 ```
 
 - **`verification_status`**: Used by publication gate — items with `'unverified'` are filtered out of the live checklist set ([`08-checklist-engine.md`](./08-checklist-engine.md)).
-- **`disclaimer_level`**: UI emphasis (e.g. high for `further_check` items); tests assert `further_check` uses `'high'`.
+- **`disclaimer_level`**: UI emphasis; high-risk items display the `需進一步確認` badge.
 
 ## Situations
 
@@ -60,7 +60,6 @@ export type CategoryId =
   | 'exemptions'
   | 'general_deductions'
   | 'special_deductions'
-  | 'further_check'
 ```
 
 Display order and human-readable labels are defined in [`src/lib/checklist.ts`](../src/lib/checklist.ts) (`CATEGORY_ORDER`, `CATEGORY_LABELS`).

--- a/ai-context/06-content-modules.md
+++ b/ai-context/06-content-modules.md
@@ -21,15 +21,15 @@ Reused constants (`SRC_ITA`, `SRC_MOF`, `SRC_MANUAL`, `SRC_TAX_SAVING_MANUAL`, `
 | `insurance-deduction` | `general_deductions` | `insurance` |
 | `medical-deduction` | `general_deductions` | `medical_expenses` |
 | `mortgage-interest-deduction` | `general_deductions` | `mortgage_interest` |
-| `salary-special-deduction` | `gross_income` | `salary_income` |
+| `gross-income` | `gross_income` | `salary_income` |
+| `dividends-tax-choice` | `gross_income` | `dividends` |
+| `overseas-income-amt` | `gross_income` | `overseas_income` |
 | `savings-investment-deduction` | `special_deductions` | `savings_investment` |
 | `disability-special-deduction` | `special_deductions` | `disability` |
 | `childcare-deduction` | `special_deductions` | `childcare` |
 | `education-tuition-deduction` | `special_deductions` | `education_tuition` |
 | `long-term-care-deduction` | `special_deductions` | `long_term_care` |
 | `rent-deduction` | `special_deductions` | `rent` |
-| `dividends-tax-choice` | `further_check` | `dividends` |
-| `overseas-income-amt` | `further_check` | `overseas_income` |
 
 Numeric prose in `why_it_matters` uses `getNumber(...).toLocaleString('zh-TW')` via local helper `n(key)`.
 
@@ -70,7 +70,6 @@ Logic and inputs live in [`src/lib/decisions.ts`](../src/lib/decisions.ts) and [
 | `rent-deduction` | `rent_amount` | `null` |
 | `medical-deduction` | `medical_amount` | `null` |
 | `donations-deduction` | `donation_amount` | `null` |
-| `salary-special-deduction` | `salary_amount` | `special_deduction_salary` |
 
 All fields: `type: 'number'`, `unit: '元'`.
 

--- a/ai-context/08-checklist-engine.md
+++ b/ai-context/08-checklist-engine.md
@@ -29,7 +29,6 @@ Fixed category sort order:
 2. `exemptions`
 3. `general_deductions`
 4. `special_deductions`
-5. `further_check`
 
 `CATEGORY_LABELS` maps each `CategoryId` to zh-TW section titles (includes note that standard vs itemized are mutually exclusive in `general_deductions`).
 

--- a/ai-context/13-testing.md
+++ b/ai-context/13-testing.md
@@ -23,7 +23,7 @@
 
 - **Publication**: no `unverified` items in published set used for UI.
 - **Married + salary**: `standard-deduction-single` excluded when `married` selected.
-- **Categories**: order `gross_income` → `exemptions` → `general_deductions` → `special_deductions` → `further_check`; `further_check` items use `disclaimer_level === 'high'`.
+- **Categories**: order `gross_income` → `exemptions` → `general_deductions` → `special_deductions`; gross income source cards remain in salary → dividends → overseas order.
 - **Situations**: count **14**; every `SituationId` has at least one published item; `SITUATION_GROUPS` union equals all ids, no duplicates, fixed subgroup ordering tests.
 - **Sources**: every item has `source_refs`, `next_action`, `why_it_matters`; `source_id` pattern; export markdown excludes internal fields like raw `source_id` / `verification_status` where tests assert privacy of export.
 - **Triage**: rules use negative boosts; `dependents_count` not a sort field; empty input map preserves order.

--- a/src/content/deductions.ts
+++ b/src/content/deductions.ts
@@ -179,7 +179,7 @@ export const CHECKLIST_ITEMS: ChecklistItem[] = [
   // ── Gross income (綜合所得總額) ─────────────────────────────────────────────
   {
     id: 'gross-income',
-    title: '綜合所得總額',
+    title: '薪資收入',
     category: 'gross_income',
     situations: ['salary_income'],
     why_it_matters: `填入去年（114年1月至12月）本人與親屬的「薪資收入」。系統自動套用「薪資所得特別扣除額」（每人最多 ${n('special_deduction_salary')} 元），計算出綜合所得總額。`,
@@ -195,6 +195,49 @@ export const CHECKLIST_ITEMS: ChecklistItem[] = [
     verification_status: 'verified',
     disclaimer_level: 'low',
     next_action: '確認申報書薪資所得欄位與薪資所得特別扣除額已正確帶入',
+  },
+  {
+    id: 'dividends-tax-choice',
+    title: '股利收入',
+    category: 'gross_income',
+    situations: ['dividends'],
+    why_it_matters: '股利所得可選擇「合併計稅」或「28%分開計稅」，須依個人綜所稅率判斷哪種方式較有利',
+    eligibility_cues: [
+      '申報年度有收到股利或盈餘分配者',
+    ],
+    documents_to_prepare: ['股利分配通知書或扣繳憑單'],
+    limitations: [
+      '兩種計稅方式各有利弊，需依個人邊際稅率判斷',
+      '選擇分開計稅者不可再享股利可抵減稅額',
+      '建議使用財政部電子申報系統試算比較',
+    ],
+    source_refs: [SRC_ITA, SRC_MOF],
+    verification_status: 'partially_verified',
+    disclaimer_level: 'high',
+    next_action: '收集全年股利憑單，使用申報系統試算兩種計稅方式後再決定',
+  },
+  {
+    id: 'overseas-income-amt',
+    title: '海外所得',
+    category: 'gross_income',
+    situations: ['overseas_income'],
+    why_it_matters: '海外所得超過所得基本稅額條例規定門檻者須計入最低稅負制（AMT），計算方式與一般綜所稅不同，稅負較複雜',
+    eligibility_cues: [
+      '全年海外所得達到所得基本稅額條例規定申報門檻者',
+      '需確認是否達到最低稅負制申報門檻（詳見所得基本稅額條例及申報書說明）',
+    ],
+    documents_to_prepare: [
+      '境外所得相關文件（匯款紀錄、境外稅單等）',
+    ],
+    limitations: [
+      '計算方式較複雜，建議諮詢稅務師或記帳士',
+      '境外稅負可申請抵扣，但有相關限制',
+      '海外所得的範圍及認定依所得稅法定義，非所有境外收入均計入',
+    ],
+    source_refs: [SRC_AMT, SRC_MANUAL],
+    verification_status: 'partially_verified',
+    disclaimer_level: 'high',
+    next_action: '確認海外所得金額，如超過門檻建議諮詢稅務師',
   },
   {
     id: 'savings-investment-deduction',
@@ -332,50 +375,6 @@ export const CHECKLIST_ITEMS: ChecklistItem[] = [
     next_action: '確認租屋自住、境內無房屋及排富條件是否符合',
   },
 
-  // ── Further check items ────────────────────────────────────────────────────
-  {
-    id: 'dividends-tax-choice',
-    title: '股利所得課稅方式（需進一步確認）',
-    category: 'further_check',
-    situations: ['dividends'],
-    why_it_matters: '股利所得可選擇「合併計稅」或「28%分開計稅」，須依個人綜所稅率判斷哪種方式較有利',
-    eligibility_cues: [
-      '申報年度有收到股利或盈餘分配者',
-    ],
-    documents_to_prepare: ['股利分配通知書或扣繳憑單'],
-    limitations: [
-      '兩種計稅方式各有利弊，需依個人邊際稅率判斷',
-      '選擇分開計稅者不可再享股利可抵減稅額',
-      '建議使用財政部電子申報系統試算比較',
-    ],
-    source_refs: [SRC_ITA, SRC_MOF],
-    verification_status: 'partially_verified',
-    disclaimer_level: 'high',
-    next_action: '收集全年股利憑單，使用申報系統試算兩種計稅方式後再決定',
-  },
-  {
-    id: 'overseas-income-amt',
-    title: '海外所得與最低稅負（需進一步確認）',
-    category: 'further_check',
-    situations: ['overseas_income'],
-    why_it_matters: '海外所得超過所得基本稅額條例規定門檻者須計入最低稅負制（AMT），計算方式與一般綜所稅不同，稅負較複雜',
-    eligibility_cues: [
-      '全年海外所得達到所得基本稅額條例規定申報門檻者',
-      '需確認是否達到最低稅負制申報門檻（詳見所得基本稅額條例及申報書說明）',
-    ],
-    documents_to_prepare: [
-      '境外所得相關文件（匯款紀錄、境外稅單等）',
-    ],
-    limitations: [
-      '計算方式較複雜，建議諮詢稅務師或記帳士',
-      '境外稅負可申請抵扣，但有相關限制',
-      '海外所得的範圍及認定依所得稅法定義，非所有境外收入均計入',
-    ],
-    source_refs: [SRC_AMT, SRC_MANUAL],
-    verification_status: 'partially_verified',
-    disclaimer_level: 'high',
-    next_action: '確認海外所得金額，如超過門檻建議諮詢稅務師',
-  },
 ]
 
 export const SITUATIONS: Situation[] = [

--- a/src/lib/checklist.ts
+++ b/src/lib/checklist.ts
@@ -22,7 +22,6 @@ const CATEGORY_ORDER: Record<CategoryId, number> = {
   exemptions: 1,
   general_deductions: 2,
   special_deductions: 3,
-  further_check: 4,
 }
 
 // 標準扣除額 and 列舉扣除額 are mutually exclusive filing choices shown together
@@ -32,7 +31,6 @@ export const CATEGORY_LABELS: Record<CategoryId, string> = {
   exemptions: '免稅額',
   general_deductions: '一般扣除額（標準或列舉擇一）',
   special_deductions: '特別扣除額',
-  further_check: '需進一步確認',
 }
 
 export interface CategoryGroup {

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -36,7 +36,6 @@ export type CategoryId =
   | 'exemptions'
   | 'general_deductions'
   | 'special_deductions'
-  | 'further_check'
 
 export interface SourceRef {
   source_id: string

--- a/tests/checklist.test.ts
+++ b/tests/checklist.test.ts
@@ -168,7 +168,7 @@ describe('filterBySituations', () => {
 describe('groupByCategory', () => {
   const published = applyPublicationGate(CHECKLIST_ITEMS)
 
-  it('returns groups in priority order: gross income before exemptions before general before special before further_check', () => {
+  it('returns groups in priority order: gross income before exemptions before general before special', () => {
     const all = filterBySituations(published, SITUATIONS.map((s) => s.id))
     const groups = groupByCategory(all)
     const categories = groups.map((g) => g.category)
@@ -176,18 +176,30 @@ describe('groupByCategory', () => {
     const exemptIdx = categories.indexOf('exemptions')
     const generalIdx = categories.indexOf('general_deductions')
     const specialIdx = categories.indexOf('special_deductions')
-    const furtherIdx = categories.indexOf('further_check')
     expect(grossIdx).toBeLessThan(exemptIdx)
     expect(exemptIdx).toBeLessThan(generalIdx)
     expect(generalIdx).toBeLessThan(specialIdx)
-    expect(specialIdx).toBeLessThan(furtherIdx)
+    expect(categories).not.toContain('further_check')
   })
 
-  it('groups salary special deduction under gross income', () => {
-    const groups = groupByCategory(filterBySituations(published, ['salary_income']))
+  it('groups income source cards under gross income in salary, dividends, overseas order', () => {
+    const groups = groupByCategory(filterBySituations(published, [
+      'salary_income',
+      'dividends',
+      'overseas_income',
+    ]))
     const gross = groups.find((g) => g.category === 'gross_income')
     expect(gross?.label).toBe('綜合所得總額')
-    expect(gross?.items.map((i) => i.id)).toContain('gross-income')
+    expect(gross?.items.map((i) => i.id)).toEqual([
+      'gross-income',
+      'dividends-tax-choice',
+      'overseas-income-amt',
+    ])
+    expect(gross?.items.map((i) => i.title)).toEqual([
+      '薪資收入',
+      '股利收入',
+      '海外所得',
+    ])
   })
 
   it('each group has a human-readable label', () => {
@@ -195,15 +207,6 @@ describe('groupByCategory', () => {
     const groups = groupByCategory(all)
     for (const group of groups) {
       expect(group.label).toBeTruthy()
-    }
-  })
-
-  it('further_check items have disclaimer_level high', () => {
-    const all = filterBySituations(published, SITUATIONS.map((s) => s.id))
-    const groups = groupByCategory(all)
-    const fc = groups.find((g) => g.category === 'further_check')
-    if (fc) {
-      expect(fc.items.every((i) => i.disclaimer_level === 'high')).toBe(true)
     }
   })
 


### PR DESCRIPTION
## Summary

- Remove CategoryId 'further_check' and related labels/order.
- Move dividends-tax-choice and overseas-income-amt to gross_income; shorten titles.
- Rename gross-income card title to 薪資收入 (salary-focused copy unchanged in body).
- Update Vitest expectations and ai-context docs.

## Checks

- [x] No personal tax data or private documents included
- [x] Tax-related claims are sourced or marked as draft
- [x] Changes are scoped to this PR
