### PR TITLE
feat: improve checklist summary flow, export placement, and header tax-year context

### DIFF
--- a/.github/scripts/render-pages-index.sh
+++ b/.github/scripts/render-pages-index.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 root="${1:?Usage: render-pages-index.sh <pages-root>}"
 production_url="${PRODUCTION_URL:-https://taiwantaxcalculator.com/}"
-generated_at="$(date -u +"%Y-%m-%d %H:%M UTC")"
+generated_at="$(TZ=Asia/Taipei date +"%Y-%m-%d %H:%M UTC+8")"
 pr_links=""
 
 if [ -d "$root/pr-preview" ]; then

--- a/ai-context/10-ui-components.md
+++ b/ai-context/10-ui-components.md
@@ -68,7 +68,7 @@ interface Props {
 
 ## Checklist card shell (`ChecklistCardShell.tsx`)
 
-Shared layout for checklist result cards: title, `why_it_matters`, situation labels, eligibility, documents, **`children`** (form or custom body), then footer `border-t` with optional wealth-clause notice when `item.show_wealth_clause_notice`, and collapsible sources. Root: `print-card`, `data-testid="checklist-card-${item.id}"`.
+Shared layout for checklist result cards: title, `why_it_matters`, eligibility, documents, **`children`** (form or custom body), then footer `border-t` with optional wealth-clause notice when `item.show_wealth_clause_notice`, and collapsible sources. Root: `print-card`, `data-testid="checklist-card-${item.id}"`.
 
 ## `DeductionCard.tsx`
 
@@ -108,7 +108,6 @@ interface Props {
 - Per-person feedback: shows 薪資所得特別扣除額 and net 薪資所得.
 - Composes same [`ChecklistCardShell`](../src/components/checklist/ChecklistCardShell.tsx) (eligibility and shared footer).
 - **`children`**: multi-person income UI, add-person control, privacy line, then in-card `綜合所得總額` breakdown (`data-testid="gross-income-total"`) matching **`calcTotalGrossIncome`** (net-of-salary-deduction sum).
-- Source situation labels: `data-testid="card-source-situations-gross-income"` (from shell).
 - Calculation logic: [`src/lib/grossIncome.ts`](../src/lib/grossIncome.ts).
 
 ## `TaxSummaryPanel.tsx`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,16 @@ import { CHECKLIST_ITEMS, SITUATIONS, SITUATION_GROUPS } from './content/deducti
 import { filterBySituations, groupByCategory } from './lib/checklist'
 import type { CategoryGroup } from './lib/checklist'
 import {
+  clearSavedChecklistInputMap,
+  loadSavedChecklistInputMap,
+  saveChecklistInputMap,
+} from './lib/checklistInputStorage'
+import {
+  clearSavedChecklistViewState,
+  loadSavedChecklistViewState,
+  saveChecklistViewState,
+} from './lib/checklistViewStateStorage'
+import {
   clearSavedSituationSelection,
   loadSavedSituationSelection,
   parseSavedSituationSelection,
@@ -149,9 +159,13 @@ function getItemSourceSituationLabelsById(
 }
 
 function App() {
-  const [appState, setAppState] = useState<AppState>('selecting')
   const [selected, setSelected] = useState<SituationId[]>(() => loadSavedSituationSelection(SITUATION_IDS))
-  const [cardInputMap, setCardInputMap] = useState<CardInputMap>({})
+  const [appState, setAppState] = useState<AppState>(() => {
+    const savedViewState = loadSavedChecklistViewState()
+    const savedSelection = loadSavedSituationSelection(SITUATION_IDS)
+    return savedViewState === 'results' && savedSelection.length > 0 ? 'results' : 'selecting'
+  })
+  const [cardInputMap, setCardInputMap] = useState<CardInputMap>(() => loadSavedChecklistInputMap())
 
   const [pendingRemovalEffect, setPendingRemovalEffect] = useState<RemovalEffect | null>(null)
   const [scrollToItemId, setScrollToItemId] = useState<string | null>(null)
@@ -159,6 +173,14 @@ function App() {
   useEffect(() => {
     saveSituationSelection(selected)
   }, [selected])
+
+  useEffect(() => {
+    saveChecklistInputMap(cardInputMap)
+  }, [cardInputMap])
+
+  useEffect(() => {
+    saveChecklistViewState(appState)
+  }, [appState])
 
   useEffect(() => {
     // Clean up deprecated pre-v2 checklist overrides data to keep refresh behavior deterministic.
@@ -170,7 +192,10 @@ function App() {
       if (event.key === SITUATION_SELECTION_STORAGE_KEY) {
         const syncedSelection = parseSavedSituationSelection(event.newValue, SITUATION_IDS)
         setSelected(syncedSelection)
-        if (syncedSelection.length === 0) setAppState('selecting')
+        if (syncedSelection.length === 0) {
+          setAppState('selecting')
+          saveChecklistViewState('selecting')
+        }
       }
     }
 
@@ -189,18 +214,30 @@ function App() {
     if (selected.length > 0) {
       setScrollToItemId(null)
       setAppState('results')
+      saveChecklistViewState('results')
       window.scrollTo(0, 0)
     }
   }
 
-  function handleClearSelections() {
+  function resetChecklistState() {
     setSelected([])
     setAppState('selecting')
     setCardInputMap({})
     setPendingRemovalEffect(null)
     setScrollToItemId(null)
     clearSavedSituationSelection()
+    clearSavedChecklistInputMap()
+    clearSavedChecklistViewState()
     localStorage.removeItem(LEGACY_MANUAL_OVERRIDES_STORAGE_KEY)
+    window.scrollTo(0, 0)
+  }
+
+  function handleClearSelections() {
+    resetChecklistState()
+  }
+
+  function handleResetCalculation() {
+    resetChecklistState()
   }
 
   function handleAddSituations(ids: SituationId[]) {
@@ -252,6 +289,7 @@ function App() {
       // Keep this behavior as the canonical UX: empty checklist returns to page one.
       setScrollToItemId(null)
       setAppState('selecting')
+      saveChecklistViewState('selecting')
       window.scrollTo(0, 0)
     }
   }
@@ -307,6 +345,7 @@ function App() {
           onConfirmRemoveItem={handleConfirmRemoveItem}
           scrollToItemId={scrollToItemId}
           onScrollHandled={() => setScrollToItemId(null)}
+          onReset={handleResetCalculation}
         />
       )
     }

--- a/src/components/ChecklistResult.tsx
+++ b/src/components/ChecklistResult.tsx
@@ -561,14 +561,6 @@ export function ChecklistResult({
                 <h2 className="mb-3 border-b border-gray-200 pb-1 text-lg font-semibold text-gray-700 flex items-baseline gap-2">
                   <span>{group.label}</span>
                   {(() => {
-                    if (
-                      group.category === 'general_deductions' &&
-                      generalDeductionResolved.status === 'pending_itemized'
-                    ) {
-                      return (
-                        <span className="text-sm font-normal text-gray-400">待填入</span>
-                      )
-                    }
                     const sub = getSectionSubtotal(group)
                     return sub !== null ? (
                       <span className="text-base font-semibold text-green-700 tabular-nums">

--- a/src/components/ChecklistResult.tsx
+++ b/src/components/ChecklistResult.tsx
@@ -11,7 +11,7 @@ import { resolveGeneralDeduction } from '../lib/generalDeductionEffective'
 import { getNumber } from '../lib/numbers'
 import { animateScrollToY } from '../lib/scrollAnimation'
 import { ITEM_INLINE_FIELDS } from '../content/inlineFields'
-import { parseGrossIncomePersons, calcTotalGrossIncome, calcPersonNetIncome } from '../lib/grossIncome'
+import { parseGrossIncomePersons, calcPersonNetIncome } from '../lib/grossIncome'
 import { FormulaRow } from './checklist/FormulaRow'
 import { StandardItemizedPanel } from './checklist/StandardItemizedPanel'
 import { DecisionToolsPanel } from './DecisionToolsPanel'
@@ -85,6 +85,8 @@ const SPECIAL_DEDUCTION_META: Record<string, { label: string; fields: SpecialFie
     fields: [{ type: 'amount', fieldId: 'rent_amount', capKey: 'special_deduction_rent' }],
   },
 }
+
+const FORMULA_SECTION_BOX_CLASS = 'rounded-lg border border-gray-200 px-4 py-3'
 
 function getSpecialDeductionItemAmount(
   itemId: string,
@@ -291,6 +293,7 @@ export function ChecklistResult({
   cardInputMap,
   pendingRemovalImpact,
   onCardInputChange,
+  onReset,
   onAddSituations,
   onRemoveItem,
   onCancelRemoveItem,
@@ -341,13 +344,13 @@ export function ChecklistResult({
     setIsAddModalOpen(false)
   }
 
-  const isMarriedFiling = selectedSituations.includes('married')
+  function handleResetClick() {
+    const shouldReset = window.confirm('重新計算會清除已選項目與所有試算資料，確定要繼續嗎？')
+    if (!shouldReset) return
+    onReset?.()
+  }
 
-  const grossIncomeTotal = useMemo(() => {
-    const inputs = cardInputMap['gross-income'] ?? {}
-    const persons = parseGrossIncomePersons(inputs, isMarriedFiling)
-    return calcTotalGrossIncome(persons)
-  }, [cardInputMap, isMarriedFiling])
+  const isMarriedFiling = selectedSituations.includes('married')
 
   const exemptionAmount = useMemo(() => {
     const inputs = cardInputMap['exemption-general'] ?? {}
@@ -364,6 +367,14 @@ export function ChecklistResult({
 
   const generalDeductionAmount =
     generalDeductionResolved.status === 'pending_itemized' ? null : generalDeductionResolved.amount
+  const generalDeductionMethod =
+    generalDeductionResolved.status === 'pending_itemized'
+      ? null
+      : generalDeductionResolved.status === 'standard_only' || generalDeductionAmount === null
+        ? 'standard'
+        : (generalDeductionAmount > getNumber(isMarriedFiling ? 'standard_deduction_married' : 'standard_deduction_single')
+            ? 'itemized'
+            : 'standard')
 
   const specialDeductionGroup = groups.find((g) => g.category === 'special_deductions')
   const hasSpecialDeductions = (specialDeductionGroup?.items.length ?? 0) > 0
@@ -395,12 +406,43 @@ export function ChecklistResult({
     if (!hasGrossIncomeCard) return null
     const inputs = cardInputMap['gross-income'] ?? {}
     const persons = parseGrossIncomePersons(inputs, isMarriedFiling)
+    const hasSelfIncomeInput = (inputs['self_income'] ?? '').trim() !== ''
+    const filledPersonIds = new Set<string>()
+    const rawPersonsJson = inputs['persons_json']
+    if (rawPersonsJson) {
+      try {
+        const parsed = JSON.parse(rawPersonsJson)
+        if (Array.isArray(parsed)) {
+          for (const person of parsed) {
+            if (
+              person &&
+              typeof person === 'object' &&
+              typeof person.id === 'string' &&
+              typeof person.income === 'number'
+            ) {
+              filledPersonIds.add(person.id)
+            }
+          }
+        }
+      } catch {
+        // Ignore malformed input and keep the row as unfilled.
+      }
+    }
     return persons.map((p) => ({
       id: p.id,
       label: p.label,
-      amount: p.income > 0 ? calcPersonNetIncome(p.income) : null,
+      amount:
+        p.id === 'self'
+          ? (hasSelfIncomeInput ? calcPersonNetIncome(p.income) : null)
+          : (filledPersonIds.has(p.id) ? calcPersonNetIncome(p.income) : null),
     }))
   }, [groups, cardInputMap, isMarriedFiling])
+
+  const grossIncomeAmount = useMemo(() => {
+    if (!grossIncomeFormulaItems || grossIncomeFormulaItems.length === 0) return null
+    if (grossIncomeFormulaItems.some((item) => item.amount === null)) return null
+    return grossIncomeFormulaItems.reduce((sum, item) => sum + (item.amount ?? 0), 0)
+  }, [grossIncomeFormulaItems])
 
   function handleScrollToSection(categoryId: string) {
     const el = sectionRefs.current[categoryId as CategoryId]
@@ -411,7 +453,7 @@ export function ChecklistResult({
   function getSectionSubtotal(group: CategoryGroup): number | null {
     switch (group.category) {
       case 'gross_income':
-        return grossIncomeTotal > 0 ? grossIncomeTotal : null
+        return grossIncomeAmount
       case 'exemptions':
         return exemptionAmount
       case 'general_deductions':
@@ -449,38 +491,48 @@ export function ChecklistResult({
         />
       )}
 
-      <div className="lg:grid lg:grid-cols-[1fr_260px] lg:gap-6 lg:items-start print-main-layout">
+      <div className="lg:grid lg:grid-cols-[1fr_300px] lg:gap-6 lg:items-start print-main-layout">
         {/* ── Main column ── */}
         <div>
           <div className="mb-1 flex items-center justify-between gap-3">
             <h1 className="text-xl font-semibold text-gray-900">節稅清單</h1>
-            <span
-              className={[
-                'no-print group relative inline-flex',
-                canAddMore ? '' : 'cursor-help',
-              ].join(' ')}
-            >
+            <div className="no-print flex items-center gap-2">
               <button
                 type="button"
-                onClick={openAddModal}
-                disabled={!canAddMore}
-                data-testid="open-add-situation-modal-btn"
+                onClick={handleResetClick}
+                data-testid="reset-checklist-btn"
+                className="inline-flex items-center rounded border border-red-300 bg-red-50 px-3 py-1.5 text-sm font-medium text-red-700 transition-colors hover:bg-red-100"
+              >
+                重新計算
+              </button>
+              <span
                 className={[
-                  'inline-flex items-center gap-1 rounded border px-3 py-1.5 text-sm font-medium transition-colors',
-                  canAddMore
-                    ? 'border-blue-300 bg-blue-50 text-blue-800 hover:bg-blue-100'
-                    : 'border-gray-200 bg-gray-50 text-gray-300',
+                  'group relative inline-flex',
+                  canAddMore ? '' : 'cursor-help',
                 ].join(' ')}
               >
-                <span aria-hidden="true">+</span>
-                <span>新增項目</span>
-              </button>
-              {!canAddMore && (
-                <span className="pointer-events-none absolute left-1/2 top-full z-10 mt-1 -translate-x-1/2 rounded bg-gray-800 px-2 py-1 text-xs text-white opacity-0 transition-opacity duration-150 whitespace-nowrap group-hover:opacity-100">
-                  所有項目都已加入
-                </span>
-              )}
-            </span>
+                <button
+                  type="button"
+                  onClick={openAddModal}
+                  disabled={!canAddMore}
+                  data-testid="open-add-situation-modal-btn"
+                  className={[
+                    'inline-flex items-center gap-1 rounded border px-3 py-1.5 text-sm font-medium transition-colors',
+                    canAddMore
+                      ? 'border-blue-300 bg-blue-50 text-blue-800 hover:bg-blue-100'
+                      : 'border-gray-200 bg-gray-50 text-gray-300',
+                  ].join(' ')}
+                >
+                  <span aria-hidden="true">+</span>
+                  <span>新增項目</span>
+                </button>
+                {!canAddMore && (
+                  <span className="pointer-events-none absolute left-1/2 top-full z-10 mt-1 -translate-x-1/2 rounded bg-gray-800 px-2 py-1 text-xs text-white opacity-0 transition-opacity duration-150 whitespace-nowrap group-hover:opacity-100">
+                    所有項目都已加入
+                  </span>
+                )}
+              </span>
+            </div>
           </div>
           <p className="mb-4 text-base text-gray-500">
             根據您選擇的 {totalSelected} 項情況，找到 {totalItems} 個值得確認的項目。
@@ -509,12 +561,6 @@ export function ChecklistResult({
                 <h2 className="mb-3 border-b border-gray-200 pb-1 text-lg font-semibold text-gray-700 flex items-baseline gap-2">
                   <span>{group.label}</span>
                   {(() => {
-                    const fItems = getFormulaItems(group)
-                    if (fItems && fItems.length > 0) {
-                      return (
-                        <span className="text-sm font-normal text-gray-400">小計（依公式計算）</span>
-                      )
-                    }
                     if (
                       group.category === 'general_deductions' &&
                       generalDeductionResolved.status === 'pending_itemized'
@@ -540,9 +586,17 @@ export function ChecklistResult({
                 )}
                 {(() => {
                   const fItems = getFormulaItems(group)
+                  const shouldWrapFormulaBox =
+                    group.category === 'gross_income' || group.category === 'special_deductions'
                   return fItems && fItems.length > 0 ? (
                     <div className="mb-4">
-                      <FormulaRow items={fItems} />
+                      {shouldWrapFormulaBox ? (
+                        <div className={FORMULA_SECTION_BOX_CLASS}>
+                          <FormulaRow items={fItems} />
+                        </div>
+                      ) : (
+                        <FormulaRow items={fItems} />
+                      )}
                     </div>
                   ) : null
                 })()}
@@ -594,9 +648,10 @@ export function ChecklistResult({
 
           <div className="print-only mt-8">
             <TaxSummaryPanel
-              grossIncome={grossIncomeTotal > 0 ? grossIncomeTotal : null}
+              grossIncome={grossIncomeAmount}
               exemptionAmount={exemptionAmount}
               generalDeductionAmount={generalDeductionAmount}
+              generalDeductionMethod={generalDeductionMethod}
               specialDeductionAmount={hasSpecialDeductions ? specialDeductionAmount : null}
               hasSpecialDeductions={hasSpecialDeductions}
               printMode
@@ -607,9 +662,10 @@ export function ChecklistResult({
         {/* ── Sidebar ── */}
         <aside className="no-print mt-6 lg:mt-0 lg:sticky lg:top-20 lg:max-h-[calc(100vh-6rem)] lg:overflow-auto">
           <TaxSummaryPanel
-            grossIncome={grossIncomeTotal > 0 ? grossIncomeTotal : null}
+            grossIncome={grossIncomeAmount}
             exemptionAmount={exemptionAmount}
             generalDeductionAmount={generalDeductionAmount}
+            generalDeductionMethod={generalDeductionMethod}
             specialDeductionAmount={hasSpecialDeductions ? specialDeductionAmount : null}
             hasSpecialDeductions={hasSpecialDeductions}
             onScrollToSection={handleScrollToSection}

--- a/src/components/ChecklistResult.tsx
+++ b/src/components/ChecklistResult.tsx
@@ -139,8 +139,8 @@ function AddSituationModal({
       <div className="w-full max-w-2xl rounded-lg border border-gray-200 bg-white shadow-xl">
         <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
           <div>
-            <h2 className="text-sm font-semibold text-gray-900">新增項目</h2>
-            <p className="mt-0.5 text-xs text-gray-500">依第一頁邏輯選擇情境後，系統會自動帶入相關卡片</p>
+            <h2 className="text-base font-semibold text-gray-900">新增項目</h2>
+            <p className="mt-0.5 text-sm text-gray-500">依第一頁邏輯選擇情境後，系統會自動帶入相關卡片</p>
           </div>
           <button
             type="button"
@@ -154,12 +154,12 @@ function AddSituationModal({
 
         <div className="max-h-96 overflow-y-auto px-4 py-4">
           {groups.length === 0 && (
-            <p className="py-8 text-center text-sm text-gray-400">目前沒有可新增的情境</p>
+            <p className="py-8 text-center text-base text-gray-400">目前沒有可新增的情境</p>
           )}
           {groups.map((group) => (
             <section key={group.id} className="mb-5">
-              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">{group.title}</p>
-              <p className="mb-2 text-xs text-gray-400">{group.description}</p>
+              <p className="text-base font-semibold text-gray-500">{group.title}</p>
+              <p className="mb-2 text-sm text-gray-400">{group.description}</p>
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 {group.situations.map((situation) => {
                   const isChecked = pendingSituationIds.includes(situation.id)
@@ -181,8 +181,8 @@ function AddSituationModal({
                         className="mt-0.5"
                       />
                       <span>
-                        <span className="block text-sm font-medium text-gray-900">{situation.label}</span>
-                        <span className="mt-0.5 block text-xs text-gray-500">{situation.description}</span>
+                        <span className="block text-base font-medium text-gray-900">{situation.label}</span>
+                        <span className="mt-0.5 block text-sm text-gray-500">{situation.description}</span>
                       </span>
                     </label>
                   )
@@ -196,7 +196,7 @@ function AddSituationModal({
           <button
             type="button"
             onClick={onCancel}
-            className="rounded border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50"
+            className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
             data-testid="cancel-add-situations-btn"
           >
             取消
@@ -207,7 +207,7 @@ function AddSituationModal({
             disabled={pendingSituationIds.length === 0}
             data-testid="confirm-add-situations-btn"
             className={[
-              'rounded px-3 py-1.5 text-xs font-medium transition-colors',
+              'rounded px-3 py-1.5 text-sm font-medium transition-colors',
               pendingSituationIds.length > 0
                 ? 'bg-blue-600 text-white hover:bg-blue-700'
                 : 'cursor-not-allowed bg-gray-100 text-gray-400',
@@ -237,11 +237,11 @@ function RemoveImpactDialog({
     <div className="fixed inset-0 z-40 flex items-center justify-center bg-gray-900/40 p-4 no-print">
       <div className="w-full max-w-lg rounded-lg border border-gray-200 bg-white shadow-xl">
         <div className="border-b border-gray-100 px-4 py-3">
-          <h2 className="text-sm font-semibold text-gray-900">確認移除此項目</h2>
+          <h2 className="text-base font-semibold text-gray-900">確認移除此項目</h2>
           <p className="mt-1 text-xs text-gray-500">{impact.itemTitle}</p>
         </div>
 
-        <div className="space-y-3 px-4 py-3 text-xs text-gray-600">
+        <div className="space-y-3 px-4 py-3 text-base text-gray-600">
           <div>
             <p className="mb-1">會一併移除的項目（{impact.removedItemTitles.length}）：</p>
             <ul className="list-disc space-y-0.5 pl-4 text-gray-700">
@@ -454,23 +454,35 @@ export function ChecklistResult({
         <div>
           <div className="mb-1 flex items-center justify-between gap-3">
             <h1 className="text-xl font-semibold text-gray-900">節稅清單</h1>
-            <button
-              type="button"
-              onClick={openAddModal}
-              disabled={!canAddMore}
-              data-testid="open-add-situation-modal-btn"
+            <span
               className={[
-                'no-print inline-flex items-center gap-1 rounded border px-3 py-1.5 text-xs font-medium transition-colors',
-                canAddMore
-                  ? 'border-blue-300 bg-blue-50 text-blue-800 hover:bg-blue-100'
-                  : 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-300',
+                'no-print group relative inline-flex',
+                canAddMore ? '' : 'cursor-help',
               ].join(' ')}
             >
-              <span aria-hidden="true">+</span>
-              <span>新增項目</span>
-            </button>
+              <button
+                type="button"
+                onClick={openAddModal}
+                disabled={!canAddMore}
+                data-testid="open-add-situation-modal-btn"
+                className={[
+                  'inline-flex items-center gap-1 rounded border px-3 py-1.5 text-sm font-medium transition-colors',
+                  canAddMore
+                    ? 'border-blue-300 bg-blue-50 text-blue-800 hover:bg-blue-100'
+                    : 'border-gray-200 bg-gray-50 text-gray-300',
+                ].join(' ')}
+              >
+                <span aria-hidden="true">+</span>
+                <span>新增項目</span>
+              </button>
+              {!canAddMore && (
+                <span className="pointer-events-none absolute left-1/2 top-full z-10 mt-1 -translate-x-1/2 rounded bg-gray-800 px-2 py-1 text-xs text-white opacity-0 transition-opacity duration-150 whitespace-nowrap group-hover:opacity-100">
+                  所有項目都已加入
+                </span>
+              )}
+            </span>
           </div>
-          <p className="mb-4 text-sm text-gray-500">
+          <p className="mb-4 text-base text-gray-500">
             根據您選擇的 {totalSelected} 項情況，找到 {totalItems} 個值得確認的項目。
           </p>
 
@@ -494,13 +506,13 @@ export function ChecklistResult({
                 }}
                 data-testid={`checklist-section-${group.category}`}
               >
-                <h2 className="mb-3 border-b border-gray-200 pb-1 text-base font-semibold text-gray-700 flex items-baseline gap-2">
+                <h2 className="mb-3 border-b border-gray-200 pb-1 text-lg font-semibold text-gray-700 flex items-baseline gap-2">
                   <span>{group.label}</span>
                   {(() => {
                     const fItems = getFormulaItems(group)
                     if (fItems && fItems.length > 0) {
                       return (
-                        <span className="text-xs font-normal text-gray-400">小計（依公式計算）</span>
+                        <span className="text-sm font-normal text-gray-400">小計（依公式計算）</span>
                       )
                     }
                     if (
@@ -508,12 +520,12 @@ export function ChecklistResult({
                       generalDeductionResolved.status === 'pending_itemized'
                     ) {
                       return (
-                        <span className="text-xs font-normal text-gray-400">待填入</span>
+                        <span className="text-sm font-normal text-gray-400">待填入</span>
                       )
                     }
                     const sub = getSectionSubtotal(group)
                     return sub !== null ? (
-                      <span className="text-sm font-semibold text-green-700 tabular-nums">
+                      <span className="text-base font-semibold text-green-700 tabular-nums">
                         {sub.toLocaleString('zh-TW')} 元
                       </span>
                     ) : null
@@ -593,7 +605,7 @@ export function ChecklistResult({
         </div>
 
         {/* ── Sidebar ── */}
-        <aside className="no-print mt-6 lg:mt-0 lg:sticky lg:top-6">
+        <aside className="no-print mt-6 lg:mt-0 lg:sticky lg:top-20 lg:max-h-[calc(100vh-6rem)] lg:overflow-auto">
           <TaxSummaryPanel
             grossIncome={grossIncomeTotal > 0 ? grossIncomeTotal : null}
             exemptionAmount={exemptionAmount}

--- a/src/components/ChecklistResult.tsx
+++ b/src/components/ChecklistResult.tsx
@@ -6,7 +6,6 @@ import type {
   SituationId,
 } from '../types/content'
 import type { CategoryGroup } from '../lib/checklist'
-import { formatChecklistMarkdown } from '../lib/exportChecklist'
 import { CHECKLIST_USAGE_REMINDER_COMPLEX_ITEMS } from '../lib/checklistCardCopy'
 import { resolveGeneralDeduction } from '../lib/generalDeductionEffective'
 import { getNumber } from '../lib/numbers'
@@ -115,8 +114,6 @@ function getSpecialDeductionItemAmount(
   }
   return total
 }
-
-type CopyState = 'idle' | 'success' | 'error'
 
 type AddSituationModalProps = {
   groups: AddableSituationGroup[]
@@ -280,94 +277,6 @@ function RemoveImpactDialog({
             確認移除
           </button>
         </div>
-      </div>
-    </div>
-  )
-}
-
-function ExportPanel({
-  groups,
-  totalSelected,
-}: {
-  groups: CategoryGroup[]
-  totalSelected: number
-}) {
-  const [copyState, setCopyState] = useState<CopyState>('idle')
-
-  function getMarkdown() {
-    return formatChecklistMarkdown(groups, {
-      totalSelected,
-      exportTime: new Date().toLocaleString('zh-TW'),
-    })
-  }
-
-  async function handleCopy() {
-    try {
-      await navigator.clipboard.writeText(getMarkdown())
-      setCopyState('success')
-      setTimeout(() => setCopyState('idle'), 2000)
-    } catch {
-      setCopyState('error')
-      setTimeout(() => setCopyState('idle'), 3000)
-    }
-  }
-
-  function handleDownload() {
-    const md = getMarkdown()
-    const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' })
-    const url = URL.createObjectURL(blob)
-    const anchor = document.createElement('a')
-    anchor.href = url
-    anchor.download = 'tax-checklist-2026.md'
-    anchor.click()
-    URL.revokeObjectURL(url)
-  }
-
-  function handlePrint() {
-    window.print()
-  }
-
-  const copyLabel =
-    copyState === 'success' ? '已複製！' : copyState === 'error' ? '複製失敗' : '複製清單'
-
-  const copyClass =
-    copyState === 'success'
-      ? 'bg-green-50 text-green-700 border-green-300'
-      : copyState === 'error'
-        ? 'bg-red-50 text-red-700 border-red-300'
-        : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
-
-  return (
-    <div className="mt-8 rounded-lg border border-blue-200 bg-blue-50 p-4">
-      <p className="mb-1 text-xs font-medium text-blue-800">匯出清單</p>
-      <p className="mb-3 text-xs text-blue-700" data-testid="export-privacy-notice">
-        本清單在您的瀏覽器中產生，未上傳至伺服器。下載或複製後，檔案可能包含個人稅務情境，請自行保管。
-      </p>
-      <div className="no-print flex flex-wrap gap-2">
-        <button
-          type="button"
-          onClick={handleCopy}
-          className={`rounded border px-3 py-1.5 text-xs font-medium transition-colors ${copyClass}`}
-          data-testid="copy-checklist-btn"
-        >
-          {copyLabel}
-        </button>
-        <button
-          type="button"
-          onClick={handleDownload}
-          className="rounded border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50"
-          data-testid="download-checklist-btn"
-        >
-          下載 Markdown
-        </button>
-        <button
-          type="button"
-          onClick={handlePrint}
-          className="rounded border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50"
-          data-testid="print-checklist-btn"
-        >
-          列印 / 另存 PDF
-        </button>
       </div>
     </div>
   )
@@ -540,7 +449,7 @@ export function ChecklistResult({
         />
       )}
 
-      <div className="lg:grid lg:grid-cols-[1fr_260px] lg:gap-6 lg:items-start">
+      <div className="lg:grid lg:grid-cols-[1fr_260px] lg:gap-6 lg:items-start print-main-layout">
         {/* ── Main column ── */}
         <div>
           <div className="mb-1 flex items-center justify-between gap-3">
@@ -551,7 +460,7 @@ export function ChecklistResult({
               disabled={!canAddMore}
               data-testid="open-add-situation-modal-btn"
               className={[
-                'inline-flex items-center gap-1 rounded border px-3 py-1.5 text-xs font-medium transition-colors',
+                'no-print inline-flex items-center gap-1 rounded border px-3 py-1.5 text-xs font-medium transition-colors',
                 canAddMore
                   ? 'border-blue-300 bg-blue-50 text-blue-800 hover:bg-blue-100'
                   : 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-300',
@@ -671,12 +580,16 @@ export function ChecklistResult({
             </p>
           </div>
 
-          {hasResults && (
-            <ExportPanel
-              groups={groups}
-              totalSelected={totalSelected}
+          <div className="print-only mt-8">
+            <TaxSummaryPanel
+              grossIncome={grossIncomeTotal > 0 ? grossIncomeTotal : null}
+              exemptionAmount={exemptionAmount}
+              generalDeductionAmount={generalDeductionAmount}
+              specialDeductionAmount={hasSpecialDeductions ? specialDeductionAmount : null}
+              hasSpecialDeductions={hasSpecialDeductions}
+              printMode
             />
-          )}
+          </div>
         </div>
 
         {/* ── Sidebar ── */}
@@ -688,6 +601,8 @@ export function ChecklistResult({
             specialDeductionAmount={hasSpecialDeductions ? specialDeductionAmount : null}
             hasSpecialDeductions={hasSpecialDeductions}
             onScrollToSection={handleScrollToSection}
+            exportGroups={hasResults ? groups : undefined}
+            exportTotalSelected={hasResults ? totalSelected : undefined}
           />
         </aside>
       </div>

--- a/src/components/ComingSoonNavItem.tsx
+++ b/src/components/ComingSoonNavItem.tsx
@@ -13,7 +13,7 @@ export function ComingSoonNavItem({ item, block = false }: Props) {
       tabIndex={-1}
       className={`${block ? 'flex' : 'inline-flex'} items-center gap-1.5 text-gray-400 cursor-not-allowed select-none`}
     >
-      <span className="text-sm">{item.label}</span>
+      <span className="text-base">{item.label}</span>
       <span className="text-xs bg-gray-100 text-gray-400 px-1.5 py-0.5 rounded-full leading-tight whitespace-nowrap">
         即將推出
       </span>

--- a/src/components/DecisionToolsPanel.tsx
+++ b/src/components/DecisionToolsPanel.tsx
@@ -45,7 +45,7 @@ export function DecisionToolsPanel({ selectedSituations }: Props) {
   if (visibleTools.length === 0) return null
 
   return (
-    <details className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm">
+    <details className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-base">
       <summary className="cursor-pointer select-none font-medium text-gray-700">
         決策工具
         <span className="ml-2 rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-800">
@@ -63,7 +63,7 @@ export function DecisionToolsPanel({ selectedSituations }: Props) {
           const Component = tool.component
           return (
             <section key={tool.id} className="border-t border-amber-200 pt-4 first:border-t-0 first:pt-0">
-              <h3 className="text-sm font-semibold text-gray-800 mb-0.5">{tool.meta.title}</h3>
+              <h3 className="text-base font-semibold text-gray-800 mb-0.5">{tool.meta.title}</h3>
               <p className="text-xs text-gray-500 mb-3">{tool.meta.subtitle}</p>
               <Component />
             </section>

--- a/src/components/GrossIncomeCard.tsx
+++ b/src/components/GrossIncomeCard.tsx
@@ -191,7 +191,7 @@ export function GrossIncomeCard({
 
         {personsInJson.map((person) => {
           const isFixed = person.id === 'spouse'
-          const incomeRaw = String(person.income === 0 && !inputValues['persons_json'] ? '' : person.income || '')
+          const incomeRaw = String(person.income === 0 && !inputValues['persons_json'] ? '' : person.income)
           const extraOrder =
             person.id.startsWith('extra-') ? extraPersonsOrdered.findIndex((p) => p.id === person.id) + 1 : 0
           const labelPlaceholder =
@@ -202,7 +202,7 @@ export function GrossIncomeCard({
             <PersonRow
               key={person.id}
               person={person}
-              incomeRaw={incomeRaw === '0' ? '' : incomeRaw}
+              incomeRaw={incomeRaw}
               isFixed={isFixed}
               labelPlaceholder={labelPlaceholder}
               onIncomeChange={(val) => handlePersonIncomeChange(person.id, val)}

--- a/src/components/GrossIncomeCard.tsx
+++ b/src/components/GrossIncomeCard.tsx
@@ -60,7 +60,7 @@ function PersonRow({
     <div className="border-b border-blue-100 last:border-0 py-3 first:pt-0 last:pb-0">
       <div className="flex items-center gap-2 mb-1.5">
         {isFixed ? (
-          <span className="text-xs font-semibold text-gray-700 min-w-[3rem]">{person.label}</span>
+          <span className="text-base font-semibold text-gray-700 min-w-[3rem]">{person.label}</span>
         ) : (
           <input
             type="text"
@@ -68,7 +68,7 @@ function PersonRow({
             onChange={(e) => onLabelChange?.(e.target.value)}
             placeholder={labelPlaceholder ?? '稱謂'}
             data-testid={`gross-income-label-${person.id}`}
-            className="text-xs font-semibold text-gray-700 border border-gray-200 rounded px-1.5 py-0.5 w-28 focus:border-blue-400 focus:outline-none"
+            className="text-base font-semibold text-gray-700 border border-gray-200 rounded px-1.5 py-0.5 w-28 focus:border-blue-400 focus:outline-none"
           />
         )}
         {!isFixed && onRemove && (
@@ -82,7 +82,7 @@ function PersonRow({
           </button>
         )}
       </div>
-      <label className="mt-1 block text-xs text-gray-500">
+      <label className="mt-1 block text-base text-gray-500">
         薪資收入
       </label>
       <div className="flex items-center gap-1.5">
@@ -93,12 +93,12 @@ function PersonRow({
           onChange={(e) => onIncomeChange(e.target.value)}
           placeholder="輸入金額"
           data-testid={`gross-income-input-${person.id}`}
-          className="w-40 rounded border border-gray-300 px-2 py-1 text-xs text-gray-800 focus:border-blue-400 focus:outline-none"
+          className="no-spin w-40 rounded border border-gray-300 px-2 py-1 text-base text-gray-800 focus:border-blue-400 focus:outline-none"
         />
-        <span className="text-xs text-gray-500">元</span>
+        <span className="text-base text-gray-500">元</span>
       </div>
       {hasIncome && (
-        <p className="mt-1.5 text-xs text-gray-500">
+        <p className="mt-1.5 text-base text-gray-500">
           {'綜合所得 ＝ 薪資收入 − 薪資所得特別扣除額 ＝ '}
           <span className="font-medium text-gray-700">{formatTwd(income)} 元</span>
           {' − '}
@@ -227,7 +227,7 @@ export function GrossIncomeCard({
         資料僅在您的瀏覽器處理，不會傳送至任何伺服器
       </p>
 
-      <div className="mt-3 text-xs text-gray-500 space-y-0.5">
+      <div className="mt-3 text-base text-gray-500 space-y-0.5">
         <p className="font-medium text-gray-700">綜合所得總額</p>
         {hasAnyIncome ? (
           <>

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -21,8 +21,8 @@ export function SiteFooter() {
 
             {/* About — Task 4.2 + 4.8 */}
             <div>
-              <h3 className="text-sm font-semibold text-gray-900 mb-2">關於本站</h3>
-              <p className="text-sm text-gray-600 leading-relaxed">
+              <h3 className="text-base font-semibold text-gray-900 mb-2">關於本站</h3>
+              <p className="text-base text-gray-600 leading-relaxed">
                 {name} 是自發整理的節稅參考工具，開源、完全免費、無商業贊助。
                 每筆資料均標示來源與更新月份。
                 本站不需帳號，所有資料均在您的裝置本機處理，不上傳伺服器。
@@ -31,8 +31,8 @@ export function SiteFooter() {
 
             {/* Disclaimer — Task 4.3 */}
             <div>
-              <h3 className="text-sm font-semibold text-gray-900 mb-2">申報提醒</h3>
-              <p className="text-sm text-gray-500 leading-relaxed">
+              <h3 className="text-base font-semibold text-gray-900 mb-2">申報提醒</h3>
+              <p className="text-base text-gray-500 leading-relaxed">
                 本站內容協助整理申報前可先檢查的項目。
                 實際申報結果以財政部、稽徵機關及官方申報系統核定為準。
               </p>
@@ -44,8 +44,8 @@ export function SiteFooter() {
 
             {/* Support / Buy me a coffee — Task 4.5 */}
             <div>
-              <h3 className="text-sm font-semibold text-gray-900 mb-2">支持我們</h3>
-              <p className="text-sm text-gray-600 mb-2">
+              <h3 className="text-base font-semibold text-gray-900 mb-2">支持我們</h3>
+              <p className="text-base text-gray-600 mb-2">
                 如果這個工具對你有幫助，歡迎請我們喝杯咖啡 ☕
               </p>
               {buyMeCoffeeUrl ? (
@@ -53,14 +53,14 @@ export function SiteFooter() {
                   href={buyMeCoffeeUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm font-medium text-teal-700 hover:text-teal-800"
+                  className="inline-flex items-center gap-1.5 text-base font-medium text-teal-700 hover:text-teal-800"
                 >
                   Buy me a coffee <ExternalLink size={13} />
                 </a>
               ) : (
                 <span
                   aria-disabled="true"
-                  className="inline-flex items-center gap-1.5 text-sm text-gray-300 cursor-not-allowed select-none"
+                  className="inline-flex items-center gap-1.5 text-base text-gray-300 cursor-not-allowed select-none"
                 >
                   Buy me a coffee <ExternalLink size={13} />
                 </span>
@@ -69,21 +69,21 @@ export function SiteFooter() {
 
             {/* Feedback — Task 4.4 */}
             <div>
-              <h3 className="text-sm font-semibold text-gray-900 mb-2">意見回報</h3>
-              <p className="text-sm text-gray-600 mb-2">資料有誤或有建議嗎？</p>
+              <h3 className="text-base font-semibold text-gray-900 mb-2">意見回報</h3>
+              <p className="text-base text-gray-600 mb-2">資料有誤或有建議嗎？</p>
               {githubNewIssueUrl ? (
                 <a
                   href={githubNewIssueUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm font-medium text-teal-700 hover:text-teal-800"
+                  className="inline-flex items-center gap-1.5 text-base font-medium text-teal-700 hover:text-teal-800"
                 >
                   填寫回報表單 <ExternalLink size={13} />
                 </a>
               ) : (
                 <span
                   aria-disabled="true"
-                  className="inline-flex items-center gap-1.5 text-sm text-gray-300 cursor-not-allowed select-none"
+                  className="inline-flex items-center gap-1.5 text-base text-gray-300 cursor-not-allowed select-none"
                 >
                   填寫回報表單 <ExternalLink size={13} />
                 </span>
@@ -95,7 +95,7 @@ export function SiteFooter() {
         {/* Official links — Task 4.7 */}
         {officialLinks.length > 0 && (
           <div className="mb-6 pt-5 border-t border-gray-100">
-            <p className="text-xs text-gray-400 mb-2">官方資源</p>
+            <p className="text-sm text-gray-400 mb-2">官方資源</p>
             <div className="flex flex-wrap gap-4">
               {officialLinks.map((link) => (
                 <a
@@ -103,7 +103,7 @@ export function SiteFooter() {
                   href={link.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+                  className="inline-flex items-center gap-1 text-base text-gray-500 hover:text-gray-700"
                 >
                   {link.label} <ExternalLink size={12} />
                 </a>
@@ -113,7 +113,7 @@ export function SiteFooter() {
         )}
 
         {/* Bottom bar — Task 4.6 */}
-        <div className="pt-4 border-t border-gray-100 flex flex-wrap gap-x-2 gap-y-1 text-xs text-gray-400">
+        <div className="pt-4 border-t border-gray-100 flex flex-wrap gap-x-2 gap-y-1 text-sm text-gray-400">
           <span>© {dataYear} {name} · {nameEn}</span>
           <span className="hidden sm:inline">·</span>
           <span>資料年度：{taxYear} 年度（{dataYear} 年 5 月申報）</span>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -12,6 +12,7 @@ interface Props {
 export function SiteHeader({ currentFeatureId }: Props) {
   const [menuOpen, setMenuOpen] = useState(false)
   const deployInfo = getDeployInfo()
+  const taxYearBadgeLabel = `${SITE_CONFIG.taxYear} 年度`
 
   // Close on Escape
   useEffect(() => {
@@ -32,18 +33,21 @@ export function SiteHeader({ currentFeatureId }: Props) {
   return (
     // position: sticky — no layout offset, unlike fixed
     <header className="sticky top-0 z-50 bg-white border-b border-gray-200">
-      <div className="max-w-5xl mx-auto px-4 h-14 flex items-center justify-between">
+      <div className="max-w-5xl mx-auto px-4 h-14 flex items-center justify-between gap-2">
 
         {/* Logo — left-aligned on all viewports (Task 1.2) */}
-        <div className="flex min-w-0 items-center gap-3">
+        <div className="flex min-w-0 items-center gap-2 sm:gap-3">
           <div className="flex min-w-0 flex-col leading-tight">
             <span className="truncate font-semibold text-gray-900 text-lg tracking-tight">
               {SITE_CONFIG.name}
             </span>
-            <span className="hidden text-xs text-gray-400 sm:block">
+            <span className="hidden text-sm text-gray-400 sm:block">
               {SITE_CONFIG.nameEn}
             </span>
           </div>
+          <span className="shrink-0 whitespace-nowrap rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-sm font-medium text-teal-700">
+            {taxYearBadgeLabel}
+          </span>
           {deployInfo && <DeployBadge deployInfo={deployInfo} />}
         </div>
 

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -37,7 +37,7 @@ export function SiteHeader({ currentFeatureId }: Props) {
         {/* Logo — left-aligned on all viewports (Task 1.2) */}
         <div className="flex min-w-0 items-center gap-3">
           <div className="flex min-w-0 flex-col leading-tight">
-            <span className="truncate font-semibold text-gray-900 text-base tracking-tight">
+            <span className="truncate font-semibold text-gray-900 text-lg tracking-tight">
               {SITE_CONFIG.name}
             </span>
             <span className="hidden text-xs text-gray-400 sm:block">
@@ -53,7 +53,7 @@ export function SiteHeader({ currentFeatureId }: Props) {
             item.status === 'active' ? (
               <span
                 key={item.id}
-                className={`text-sm font-medium pb-0.5 transition-colors ${
+                className={`text-base font-medium pb-0.5 transition-colors ${
                   currentFeatureId === item.id
                     ? 'text-teal-700 border-b-2 border-teal-700'
                     : 'text-gray-600 hover:text-gray-900'
@@ -90,7 +90,7 @@ export function SiteHeader({ currentFeatureId }: Props) {
             item.status === 'active' ? (
               <span
                 key={item.id}
-                className={`text-sm font-medium py-2 ${
+                className={`text-base font-medium py-2 ${
                   currentFeatureId === item.id ? 'text-teal-700' : 'text-gray-700'
                 }`}
               >

--- a/src/components/SituationSelector.tsx
+++ b/src/components/SituationSelector.tsx
@@ -23,10 +23,10 @@ export function SituationSelector({ groups, situations, selected, onToggle, onCl
       <div className="mb-8">
         {groups.map((group) => (
           <div key={group.id} className="mb-6">
-            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-0.5">
+            <p className="text-base font-semibold text-gray-500 mb-0.5">
               {group.title}
             </p>
-            <p className="text-xs text-gray-400 mb-2">{group.description}</p>
+            <p className="text-sm text-gray-400 mb-2">{group.description}</p>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
               {group.situationIds.map((id) => {
                 const s = situationMap.get(id)
@@ -45,8 +45,8 @@ export function SituationSelector({ groups, situations, selected, onToggle, onCl
                         : 'border-gray-200 bg-white text-gray-800 hover:border-gray-400',
                     ].join(' ')}
                   >
-                    <span className="font-medium text-sm block">{s.label}</span>
-                    <span className="text-xs text-gray-500 mt-0.5 block">{s.description}</span>
+                    <span className="font-medium text-base block">{s.label}</span>
+                    <span className="text-sm text-gray-500 mt-0.5 block">{s.description}</span>
                   </button>
                 )
               })}

--- a/src/components/TaxSummaryPanel.tsx
+++ b/src/components/TaxSummaryPanel.tsx
@@ -26,7 +26,7 @@ function GoFill({ sectionId, onScroll }: { sectionId: string; onScroll?: (id: st
     <button
       type="button"
       onClick={() => onScroll?.(sectionId)}
-      className="text-xs font-medium text-blue-600 hover:text-blue-800 hover:underline underline-offset-2 transition-colors shrink-0"
+      className="text-base font-medium text-blue-600 hover:text-blue-800 hover:underline underline-offset-2 transition-colors shrink-0"
     >
       前往填寫
     </button>
@@ -51,17 +51,17 @@ function SummaryRow({
   const hasVal = value !== null && !missing
   return (
     <div className="flex items-baseline justify-between gap-2">
-      <span className={`text-xs shrink-0 ${hasVal ? 'text-gray-500' : missing ? 'text-gray-400' : 'text-gray-300'}`}>
+      <span className={`text-base shrink-0 ${hasVal ? 'text-gray-500' : missing ? 'text-gray-400' : 'text-gray-300'}`}>
         {label}
       </span>
       {missing ? (
         <GoFill sectionId={sectionId} onScroll={onScroll} />
       ) : hasVal ? (
-        <span className="text-sm font-semibold tabular-nums text-gray-800 shrink-0">
+        <span className="text-base font-semibold tabular-nums text-gray-800 shrink-0">
           {isDeduction ? '−' : ''}{fmt(value!)} 元
         </span>
       ) : (
-        <span className="text-sm text-gray-200 shrink-0">—</span>
+        <span className="text-base text-gray-200 shrink-0">—</span>
       )}
     </div>
   )
@@ -72,21 +72,21 @@ function TaxFormulaDialog({ onClose }: { onClose: () => void }) {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/40 p-4">
       <div className="w-full max-w-lg rounded-xl border border-gray-200 bg-white shadow-2xl overflow-hidden">
         <div className="flex items-center justify-between border-b border-gray-100 px-5 py-3.5">
-          <h2 className="text-sm font-semibold text-gray-900">「所得稅應納稅額」公式</h2>
+          <h2 className="text-base font-semibold text-gray-900">「所得稅應納稅額」公式</h2>
           <button
             type="button"
             onClick={onClose}
             aria-label="關閉"
-            className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-gray-200 text-sm text-gray-500 hover:border-gray-300 hover:bg-gray-100 transition-colors"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-gray-200 text-base text-gray-500 hover:border-gray-300 hover:bg-gray-100 transition-colors"
           >
             ×
           </button>
         </div>
         <div className="px-5 py-4">
-          <p className="text-sm text-gray-700 mb-4">
+          <p className="text-base text-gray-700 mb-4">
             公式：<span className="font-semibold text-gray-900">「綜合所得淨額」× 稅率 − 累進差額</span>
           </p>
-          <table className="w-full text-xs border-collapse">
+          <table className="w-full text-base border-collapse">
             <thead>
               <tr className="bg-gray-700 text-white">
                 <th className="px-3 py-2 text-left font-semibold rounded-tl-md">綜合所得淨額區間</th>
@@ -120,7 +120,7 @@ function TaxFormulaDialog({ onClose }: { onClose: () => void }) {
           <button
             type="button"
             onClick={onClose}
-            className="rounded border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+            className="rounded border border-gray-300 bg-white px-4 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
           >
             關閉
           </button>
@@ -201,26 +201,26 @@ function TaxSummaryBody({
         {/* Divider + net income */}
         <div className="border-t border-dashed border-gray-200 pt-2.5 space-y-1.5">
           <div className="flex items-baseline justify-between gap-2">
-            <span className={`text-xs font-medium shrink-0 ${netIncome !== null ? 'text-gray-600' : 'text-gray-300'}`}>
+            <span className={`text-base font-medium shrink-0 ${netIncome !== null ? 'text-gray-600' : 'text-gray-300'}`}>
               所得淨額
             </span>
             {netIncome !== null ? (
-              <span className="text-sm font-bold tabular-nums text-gray-900">{fmt(netIncome)} 元</span>
+              <span className="text-base font-bold tabular-nums text-gray-900">{fmt(netIncome)} 元</span>
             ) : (
-              <span className="text-xs text-gray-300">待計算</span>
+              <span className="text-sm text-gray-300">待計算</span>
             )}
           </div>
 
           {/* Tax label + detail dialog */}
           <div className="flex items-baseline gap-1.5">
-            <span className="text-xs text-gray-500 shrink-0">所得稅應納稅額</span>
+            <span className="text-base text-gray-500 shrink-0">所得稅應納稅額</span>
             {onOpenDialog && (
-              <span className="shrink-0 text-[11px] text-gray-400">
+              <span className="shrink-0 text-sm text-gray-400">
                 <span aria-hidden>(</span>
                 <button
                   type="button"
                   onClick={onOpenDialog}
-                  className="inline p-0 border-0 bg-transparent font-inherit text-[11px] text-gray-400 hover:text-blue-600 hover:underline underline-offset-2 transition-colors cursor-pointer"
+                  className="inline p-0 border-0 bg-transparent font-inherit text-sm text-gray-400 hover:text-blue-600 hover:underline underline-offset-2 transition-colors cursor-pointer"
                 >
                   瞭解更多
                 </button>
@@ -233,14 +233,14 @@ function TaxSummaryBody({
           {netIncome !== null && bracket && (
             <div className="pl-2 space-y-0.5 border-l-2 border-gray-100">
               <div className="flex items-baseline justify-between gap-1">
-                <span className="text-[11px] text-gray-400">× 稅率</span>
-                <span className="text-[11px] font-semibold text-gray-500 tabular-nums">
+                <span className="text-base text-gray-400">× 稅率</span>
+                <span className="text-base font-semibold text-gray-500 tabular-nums">
                   {(bracket.rate * 100).toFixed(0)}%
                 </span>
               </div>
               <div className="flex items-baseline justify-between gap-1">
-                <span className="text-[11px] text-gray-400">− 累進差額</span>
-                <span className="text-[11px] font-semibold text-gray-500 tabular-nums">
+                <span className="text-base text-gray-400">− 累進差額</span>
+                <span className="text-base font-semibold text-gray-500 tabular-nums">
                   {fmt(bracket.quick_deduction)} 元
                 </span>
               </div>
@@ -258,13 +258,13 @@ function TaxSummaryBody({
         }`}
       >
         <div className="flex items-center justify-between gap-2">
-          <span className={`text-xs font-semibold ${taxAmount !== null ? 'text-blue-800' : 'text-gray-400'}`}>
+          <span className={`text-base font-semibold ${taxAmount !== null ? 'text-blue-800' : 'text-gray-400'}`}>
             應納稅額
           </span>
           {taxAmount !== null ? (
             <span className="text-base font-bold tabular-nums text-blue-700">{fmt(taxAmount)} 元</span>
           ) : (
-            <span className="text-xs text-gray-300">待計算</span>
+            <span className="text-sm text-gray-300">待計算</span>
           )}
         </div>
       </div>
@@ -360,14 +360,14 @@ export function TaxSummaryPanel({
         {/* Header */}
         <div className="border-b border-gray-100 px-4 py-3">
           <div className="flex items-center justify-between gap-2">
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+            <h3 className="text-lg font-semibold uppercase tracking-wide text-gray-500">
               節稅試算摘要
             </h3>
             {!printMode && showExport && (
               <div ref={exportMenuRef} className="relative no-print">
                 <button
                   type="button"
-                  className="rounded border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                  className="rounded border border-gray-300 bg-white px-2.5 py-1 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
                   onClick={() => setExportMenuOpen((v) => !v)}
                   aria-haspopup="menu"
                   aria-expanded={exportMenuOpen}
@@ -382,7 +382,7 @@ export function TaxSummaryPanel({
                         handleDownload()
                         setExportMenuOpen(false)
                       }}
-                      className="block w-full px-3 py-2 text-left text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                      className="block w-full px-3 py-2 text-left text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
                       data-testid="download-checklist-btn"
                     >
                       下載 Markdown
@@ -393,7 +393,7 @@ export function TaxSummaryPanel({
                         handlePrint()
                         setExportMenuOpen(false)
                       }}
-                      className="block w-full px-3 py-2 text-left text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                      className="block w-full px-3 py-2 text-left text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
                       data-testid="print-checklist-btn"
                     >
                       列印 / 另存 PDF

--- a/src/components/TaxSummaryPanel.tsx
+++ b/src/components/TaxSummaryPanel.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { calcTax, getBrackets } from '../lib/numbers'
+import { formatChecklistMarkdown } from '../lib/exportChecklist'
+import type { CategoryGroup } from '../lib/checklist'
 
 interface Props {
   grossIncome: number | null
@@ -9,6 +11,10 @@ interface Props {
   specialDeductionAmount: number | null
   hasSpecialDeductions: boolean
   onScrollToSection?: (categoryId: string) => void
+  /** When provided (and groups non-empty) renders the inline export controls */
+  exportGroups?: CategoryGroup[]
+  exportTotalSelected?: number
+  printMode?: boolean
 }
 
 function fmt(n: number) {
@@ -124,6 +130,148 @@ function TaxFormulaDialog({ onClose }: { onClose: () => void }) {
   )
 }
 
+interface SummaryBodyProps {
+  grossIncome: number | null
+  exemptionAmount: number | null
+  generalDeductionAmount: number | null
+  specialDeductionAmount: number | null
+  hasSpecialDeductions: boolean
+  netIncome: number | null
+  taxAmount: number | null
+  bracket: ReturnType<typeof getBrackets>[number] | null
+  onScrollToSection?: (categoryId: string) => void
+  onOpenDialog?: () => void
+}
+
+function TaxSummaryBody({
+  grossIncome,
+  exemptionAmount,
+  generalDeductionAmount,
+  specialDeductionAmount,
+  hasSpecialDeductions,
+  netIncome,
+  taxAmount,
+  bracket,
+  onScrollToSection,
+  onOpenDialog,
+}: SummaryBodyProps) {
+  const grossMissing = grossIncome === null
+  const exemptMissing = exemptionAmount === null
+  const generalMissing = generalDeductionAmount === null
+  const specialMissing = hasSpecialDeductions && specialDeductionAmount === null
+
+  return (
+    <>
+      {/* Calculation rows */}
+      <div className="px-4 py-3 space-y-2.5">
+        <SummaryRow
+          label="綜合所得總額"
+          value={grossIncome}
+          missing={grossMissing}
+          sectionId="gross_income"
+          onScroll={onScrollToSection}
+        />
+        <SummaryRow
+          label="免稅額"
+          value={exemptionAmount}
+          isDeduction
+          missing={exemptMissing}
+          sectionId="exemptions"
+          onScroll={onScrollToSection}
+        />
+        <SummaryRow
+          label="一般扣除額"
+          value={generalDeductionAmount}
+          isDeduction
+          missing={generalMissing}
+          sectionId="general_deductions"
+          onScroll={onScrollToSection}
+        />
+        {hasSpecialDeductions && (
+          <SummaryRow
+            label="特別扣除額"
+            value={specialDeductionAmount}
+            isDeduction
+            missing={specialMissing}
+            sectionId="special_deductions"
+            onScroll={onScrollToSection}
+          />
+        )}
+
+        {/* Divider + net income */}
+        <div className="border-t border-dashed border-gray-200 pt-2.5 space-y-1.5">
+          <div className="flex items-baseline justify-between gap-2">
+            <span className={`text-xs font-medium shrink-0 ${netIncome !== null ? 'text-gray-600' : 'text-gray-300'}`}>
+              所得淨額
+            </span>
+            {netIncome !== null ? (
+              <span className="text-sm font-bold tabular-nums text-gray-900">{fmt(netIncome)} 元</span>
+            ) : (
+              <span className="text-xs text-gray-300">待計算</span>
+            )}
+          </div>
+
+          {/* Tax label + detail dialog */}
+          <div className="flex items-baseline gap-1.5">
+            <span className="text-xs text-gray-500 shrink-0">所得稅應納稅額</span>
+            {onOpenDialog && (
+              <span className="shrink-0 text-[11px] text-gray-400">
+                <span aria-hidden>(</span>
+                <button
+                  type="button"
+                  onClick={onOpenDialog}
+                  className="inline p-0 border-0 bg-transparent font-inherit text-[11px] text-gray-400 hover:text-blue-600 hover:underline underline-offset-2 transition-colors cursor-pointer"
+                >
+                  瞭解更多
+                </button>
+                <span aria-hidden>)</span>
+              </span>
+            )}
+          </div>
+
+          {/* Bracket formula */}
+          {netIncome !== null && bracket && (
+            <div className="pl-2 space-y-0.5 border-l-2 border-gray-100">
+              <div className="flex items-baseline justify-between gap-1">
+                <span className="text-[11px] text-gray-400">× 稅率</span>
+                <span className="text-[11px] font-semibold text-gray-500 tabular-nums">
+                  {(bracket.rate * 100).toFixed(0)}%
+                </span>
+              </div>
+              <div className="flex items-baseline justify-between gap-1">
+                <span className="text-[11px] text-gray-400">− 累進差額</span>
+                <span className="text-[11px] font-semibold text-gray-500 tabular-nums">
+                  {fmt(bracket.quick_deduction)} 元
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Tax amount card */}
+      <div
+        className={`mx-3 mb-3 rounded-lg border px-3 py-2.5 transition-all ${
+          taxAmount !== null
+            ? 'border-blue-200 bg-blue-50'
+            : 'border-dashed border-gray-200 bg-gray-50'
+        }`}
+      >
+        <div className="flex items-center justify-between gap-2">
+          <span className={`text-xs font-semibold ${taxAmount !== null ? 'text-blue-800' : 'text-gray-400'}`}>
+            應納稅額
+          </span>
+          {taxAmount !== null ? (
+            <span className="text-base font-bold tabular-nums text-blue-700">{fmt(taxAmount)} 元</span>
+          ) : (
+            <span className="text-xs text-gray-300">待計算</span>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
 export function TaxSummaryPanel({
   grossIncome,
   exemptionAmount,
@@ -131,8 +279,58 @@ export function TaxSummaryPanel({
   specialDeductionAmount,
   hasSpecialDeductions,
   onScrollToSection,
+  exportGroups,
+  exportTotalSelected,
+  printMode = false,
 }: Props) {
   const [dialogOpen, setDialogOpen] = useState(false)
+  const [exportMenuOpen, setExportMenuOpen] = useState(false)
+  const exportMenuRef = useRef<HTMLDivElement | null>(null)
+
+  const showExport =
+    Array.isArray(exportGroups) &&
+    exportGroups.length > 0 &&
+    typeof exportTotalSelected === 'number'
+
+  function getMarkdown() {
+    return formatChecklistMarkdown(exportGroups ?? [], {
+      totalSelected: exportTotalSelected ?? 0,
+      exportTime: new Date().toLocaleString('zh-TW'),
+    })
+  }
+
+  function handleDownload() {
+    const md = getMarkdown()
+    const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = 'tax-checklist-2026.md'
+    anchor.click()
+    URL.revokeObjectURL(url)
+  }
+
+  function handlePrint() {
+    window.print()
+  }
+
+  useEffect(() => {
+    if (!exportMenuOpen) return
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setExportMenuOpen(false)
+    }
+    function onPointerDown(event: MouseEvent) {
+      if (!exportMenuRef.current?.contains(event.target as Node)) {
+        setExportMenuOpen(false)
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('mousedown', onPointerDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('mousedown', onPointerDown)
+    }
+  }, [exportMenuOpen])
 
   const netIncome =
     grossIncome !== null &&
@@ -154,134 +352,71 @@ export function TaxSummaryPanel({
       ? (getBrackets().find((b) => b.up_to === null || netIncome <= b.up_to) ?? null)
       : null
 
-  const grossMissing = grossIncome === null
-  const exemptMissing = exemptionAmount === null
-  const generalMissing = generalDeductionAmount === null
-  const specialMissing = hasSpecialDeductions && specialDeductionAmount === null
-
   return (
     <>
-      {dialogOpen && <TaxFormulaDialog onClose={() => setDialogOpen(false)} />}
+      {!printMode && dialogOpen && <TaxFormulaDialog onClose={() => setDialogOpen(false)} />}
 
-      <div className="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
+      <div className="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden print-summary-card">
         {/* Header */}
         <div className="border-b border-gray-100 px-4 py-3">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
-            節稅試算摘要
-          </h3>
-        </div>
-
-        {/* Calculation rows */}
-        <div className="px-4 py-3 space-y-2.5">
-          <SummaryRow
-            label="綜合所得總額"
-            value={grossIncome}
-            missing={grossMissing}
-            sectionId="gross_income"
-            onScroll={onScrollToSection}
-          />
-          <SummaryRow
-            label="免稅額"
-            value={exemptionAmount}
-            isDeduction
-            missing={exemptMissing}
-            sectionId="exemptions"
-            onScroll={onScrollToSection}
-          />
-          <SummaryRow
-            label="一般扣除額"
-            value={generalDeductionAmount}
-            isDeduction
-            missing={generalMissing}
-            sectionId="general_deductions"
-            onScroll={onScrollToSection}
-          />
-          {hasSpecialDeductions && (
-            <SummaryRow
-              label="特別扣除額"
-              value={specialDeductionAmount}
-              isDeduction
-              missing={specialMissing}
-              sectionId="special_deductions"
-              onScroll={onScrollToSection}
-            />
-          )}
-
-          {/* Divider + net income */}
-          <div className="border-t border-dashed border-gray-200 pt-2.5 space-y-1.5">
-            <div className="flex items-baseline justify-between gap-2">
-              <span className={`text-xs font-medium shrink-0 ${netIncome !== null ? 'text-gray-600' : 'text-gray-300'}`}>
-                所得淨額
-              </span>
-              {netIncome !== null ? (
-                <span className="text-sm font-bold tabular-nums text-gray-900">{fmt(netIncome)} 元</span>
-              ) : (
-                <span className="text-xs text-gray-300">待計算</span>
-              )}
-            </div>
-
-            {/* Tax label + 瞭解更多 */}
-            <div className="flex items-baseline gap-1.5">
-              <span className="text-xs text-gray-500 shrink-0">所得稅應納稅額</span>
-              <span className="shrink-0 text-[11px] text-gray-400">
-                <span aria-hidden>(</span>
+          <div className="flex items-center justify-between gap-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              節稅試算摘要
+            </h3>
+            {!printMode && showExport && (
+              <div ref={exportMenuRef} className="relative no-print">
                 <button
                   type="button"
-                  onClick={() => setDialogOpen(true)}
-                  className="inline p-0 border-0 bg-transparent font-inherit text-[11px] text-gray-400 hover:text-blue-600 hover:underline underline-offset-2 transition-colors cursor-pointer"
+                  className="rounded border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                  onClick={() => setExportMenuOpen((v) => !v)}
+                  aria-haspopup="menu"
+                  aria-expanded={exportMenuOpen}
                 >
-                  瞭解更多
+                  匯出
                 </button>
-                <span aria-hidden>)</span>
-              </span>
-            </div>
-
-            {/* Bracket formula */}
-            {netIncome !== null && bracket && (
-              <div className="pl-2 space-y-0.5 border-l-2 border-gray-100">
-                <div className="flex items-baseline justify-between gap-1">
-                  <span className="text-[11px] text-gray-400">× 稅率</span>
-                  <span className="text-[11px] font-semibold text-gray-500 tabular-nums">
-                    {(bracket.rate * 100).toFixed(0)}%
-                  </span>
-                </div>
-                <div className="flex items-baseline justify-between gap-1">
-                  <span className="text-[11px] text-gray-400">− 累進差額</span>
-                  <span className="text-[11px] font-semibold text-gray-500 tabular-nums">
-                    {fmt(bracket.quick_deduction)} 元
-                  </span>
-                </div>
+                {exportMenuOpen && (
+                  <div className="absolute right-0 top-8 z-10 w-44 overflow-hidden rounded-md border border-gray-200 bg-white shadow-lg">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        handleDownload()
+                        setExportMenuOpen(false)
+                      }}
+                      className="block w-full px-3 py-2 text-left text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                      data-testid="download-checklist-btn"
+                    >
+                      下載 Markdown
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        handlePrint()
+                        setExportMenuOpen(false)
+                      }}
+                      className="block w-full px-3 py-2 text-left text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                      data-testid="print-checklist-btn"
+                    >
+                      列印 / 另存 PDF
+                    </button>
+                  </div>
+                )}
               </div>
             )}
           </div>
         </div>
 
-        {/* Tax amount card */}
-        <div
-          className={`mx-3 mb-3 rounded-lg border px-3 py-2.5 transition-all ${
-            taxAmount !== null
-              ? 'border-blue-200 bg-blue-50'
-              : 'border-dashed border-gray-200 bg-gray-50'
-          }`}
-        >
-          <div className="flex items-center justify-between gap-2">
-            <span className={`text-xs font-semibold ${taxAmount !== null ? 'text-blue-800' : 'text-gray-400'}`}>
-              應納稅額
-            </span>
-            {taxAmount !== null ? (
-              <span className="text-base font-bold tabular-nums text-blue-700">{fmt(taxAmount)} 元</span>
-            ) : (
-              <span className="text-xs text-gray-300">待計算</span>
-            )}
-          </div>
-        </div>
-
-        {/* Footer */}
-        <div className="border-t border-gray-50 bg-gray-50 px-4 py-2">
-          <p className="text-xs text-gray-400 leading-relaxed">
-            填入各項金額後，此處將顯示試算結果
-          </p>
-        </div>
+        <TaxSummaryBody
+          grossIncome={grossIncome}
+          exemptionAmount={exemptionAmount}
+          generalDeductionAmount={generalDeductionAmount}
+          specialDeductionAmount={specialDeductionAmount}
+          hasSpecialDeductions={hasSpecialDeductions}
+          netIncome={netIncome}
+          taxAmount={taxAmount}
+          bracket={bracket}
+          onScrollToSection={onScrollToSection}
+          onOpenDialog={printMode ? undefined : () => setDialogOpen(true)}
+        />
       </div>
     </>
   )

--- a/src/components/TaxSummaryPanel.tsx
+++ b/src/components/TaxSummaryPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
 import { calcTax, getBrackets } from '../lib/numbers'
 import { formatChecklistMarkdown } from '../lib/exportChecklist'
 import type { CategoryGroup } from '../lib/checklist'
@@ -8,6 +9,7 @@ interface Props {
   exemptionAmount: number | null
   /** null when itemized cards exist but amounts are not all filled */
   generalDeductionAmount: number | null
+  generalDeductionMethod?: 'standard' | 'itemized' | null
   specialDeductionAmount: number | null
   hasSpecialDeductions: boolean
   onScrollToSection?: (categoryId: string) => void
@@ -41,7 +43,7 @@ function SummaryRow({
   sectionId,
   onScroll,
 }: {
-  label: string
+  label: ReactNode
   value: number | null
   isDeduction?: boolean
   missing?: boolean
@@ -89,20 +91,25 @@ function TaxFormulaDialog({ onClose }: { onClose: () => void }) {
           <table className="w-full text-base border-collapse">
             <thead>
               <tr className="bg-gray-700 text-white">
-                <th className="px-3 py-2 text-left font-semibold rounded-tl-md">綜合所得淨額區間</th>
+                <th className="px-3 py-2 text-center font-semibold rounded-tl-md">綜合所得淨額區間</th>
                 <th className="px-3 py-2 text-center font-semibold">稅率</th>
-                <th className="px-3 py-2 text-right font-semibold rounded-tr-md">累進差額</th>
+                <th className="px-3 py-2 text-center font-semibold rounded-tr-md">累進差額</th>
               </tr>
             </thead>
             <tbody>
               {getBrackets().map((b, i) => {
                 const prev = getBrackets()[i - 1]
                 const from = i === 0 ? '0' : fmt((prev.up_to ?? 0) + 1)
-                const to = b.up_to ? `${fmt(b.up_to)} 元` : '以上'
+                const fromLabel = from
+                const toLabel = b.up_to ? `${fmt(b.up_to)} 元` : '元以上'
                 return (
                   <tr key={i} className={i % 2 === 0 ? 'bg-gray-50' : 'bg-white'}>
                     <td className="px-3 py-2 font-medium text-gray-700">
-                      {from}{b.up_to ? ` – ${to}` : ' 元' + to}
+                      <span className="inline-grid grid-cols-[9ch_auto_11ch] items-baseline gap-x-2 tabular-nums">
+                        <span className="text-right">{fromLabel}</span>
+                        <span className="text-center">{b.up_to ? '–' : ''}</span>
+                        <span className={b.up_to ? 'text-right' : 'text-left'}>{toLabel}</span>
+                      </span>
                     </td>
                     <td className="px-3 py-2 text-center font-semibold text-gray-900">
                       {(b.rate * 100).toFixed(0)}%
@@ -134,6 +141,7 @@ interface SummaryBodyProps {
   grossIncome: number | null
   exemptionAmount: number | null
   generalDeductionAmount: number | null
+  generalDeductionMethod?: 'standard' | 'itemized' | null
   specialDeductionAmount: number | null
   hasSpecialDeductions: boolean
   netIncome: number | null
@@ -147,6 +155,7 @@ function TaxSummaryBody({
   grossIncome,
   exemptionAmount,
   generalDeductionAmount,
+  generalDeductionMethod,
   specialDeductionAmount,
   hasSpecialDeductions,
   netIncome,
@@ -180,7 +189,19 @@ function TaxSummaryBody({
           onScroll={onScrollToSection}
         />
         <SummaryRow
-          label="一般扣除額"
+          label={(
+            <span className="inline-flex items-center gap-2">
+              <span>一般扣除額</span>
+              {generalDeductionMethod && (
+                <span
+                  data-testid="general-deduction-method-label"
+                  className="inline-flex items-center rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-sm font-medium text-indigo-700"
+                >
+                  {generalDeductionMethod === 'itemized' ? '列舉' : '標準'}
+                </span>
+              )}
+            </span>
+          )}
           value={generalDeductionAmount}
           isDeduction
           missing={generalMissing}
@@ -276,6 +297,7 @@ export function TaxSummaryPanel({
   grossIncome,
   exemptionAmount,
   generalDeductionAmount,
+  generalDeductionMethod,
   specialDeductionAmount,
   hasSpecialDeductions,
   onScrollToSection,
@@ -409,6 +431,7 @@ export function TaxSummaryPanel({
           grossIncome={grossIncome}
           exemptionAmount={exemptionAmount}
           generalDeductionAmount={generalDeductionAmount}
+          generalDeductionMethod={generalDeductionMethod}
           specialDeductionAmount={specialDeductionAmount}
           hasSpecialDeductions={hasSpecialDeductions}
           netIncome={netIncome}

--- a/src/components/checklist/ChecklistCardSection.tsx
+++ b/src/components/checklist/ChecklistCardSection.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react'
 export function ChecklistCardSection({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="mb-2">
-      <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">{label}</span>
+      <span className="text-sm font-medium text-gray-500">{label}</span>
       <div className="mt-1">{children}</div>
     </div>
   )

--- a/src/components/checklist/ChecklistCardShell.tsx
+++ b/src/components/checklist/ChecklistCardShell.tsx
@@ -27,7 +27,7 @@ export function ChecklistCardShell({
       data-testid={`checklist-card-${item.id}`}
     >
       <div className="flex items-start gap-2 mb-2">
-        <h3 className="font-medium text-gray-900 flex-1 text-sm">{item.title}</h3>
+        <h3 className="font-medium text-gray-900 flex-1 text-base">{item.title}</h3>
         {removable && onRemove && (
           <button
             type="button"
@@ -41,13 +41,13 @@ export function ChecklistCardShell({
         )}
       </div>
 
-      <p className="text-sm text-gray-700 mb-3">{item.why_it_matters}</p>
+      <p className="text-base text-gray-700 mb-3">{item.why_it_matters}</p>
 
       {item.eligibility_cues.length > 0 && (
         <ChecklistCardSection label="適用條件">
           <ul className="list-disc list-inside space-y-0.5">
             {item.eligibility_cues.map((cue) => (
-              <li key={cue} className="text-xs text-gray-600">{cue}</li>
+              <li key={cue} className="text-sm text-gray-600">{cue}</li>
             ))}
           </ul>
         </ChecklistCardSection>
@@ -57,7 +57,7 @@ export function ChecklistCardShell({
         <ChecklistCardSection label="需準備文件">
           <ul className="list-disc list-inside space-y-0.5">
             {item.documents_to_prepare.map((doc) => (
-              <li key={doc} className="text-xs text-gray-600">{doc}</li>
+              <li key={doc} className="text-sm text-gray-600">{doc}</li>
             ))}
           </ul>
         </ChecklistCardSection>

--- a/src/components/checklist/ChecklistCardShell.tsx
+++ b/src/components/checklist/ChecklistCardShell.tsx
@@ -19,8 +19,7 @@ export function ChecklistCardShell({
   onRemove,
   children,
 }: ChecklistCardShellProps) {
-  const visibleSourceLabels = sourceSituationLabels.slice(0, 2)
-  const hiddenSourceCount = sourceSituationLabels.length - visibleSourceLabels.length
+  void sourceSituationLabels
 
   return (
     <div
@@ -43,17 +42,6 @@ export function ChecklistCardShell({
       </div>
 
       <p className="text-sm text-gray-700 mb-3">{item.why_it_matters}</p>
-
-      {sourceSituationLabels.length > 0 && (
-        <p
-          className="mb-3 text-xs text-indigo-700"
-          data-testid={`card-source-situations-${item.id}`}
-          title={`情境：${sourceSituationLabels.join('、')}`}
-        >
-          情境：{visibleSourceLabels.join('、')}
-          {hiddenSourceCount > 0 ? ` +${hiddenSourceCount}` : ''}
-        </p>
-      )}
 
       {item.eligibility_cues.length > 0 && (
         <ChecklistCardSection label="適用條件">

--- a/src/components/checklist/ChecklistInlineAmountFields.tsx
+++ b/src/components/checklist/ChecklistInlineAmountFields.tsx
@@ -17,7 +17,7 @@ function InlineFeedback({ field, value }: { field: CardInlineField; value: strin
     const additionalCount = Math.max(count - 1, 0)
     const total = firstRate + additionalCount * additionalRate
     return (
-      <p className="mt-1 text-xs text-blue-700">
+      <p className="mt-1 text-base text-blue-700">
         {count === 1 ? (
           <>1 {field.unit} × {firstRate.toLocaleString('zh-TW')} 元 ＝ <strong>{total.toLocaleString('zh-TW')} 元</strong></>
         ) : (
@@ -38,7 +38,7 @@ function InlineFeedback({ field, value }: { field: CardInlineField; value: strin
     }
     const total = count * perUnit
     return (
-      <p className="mt-1 text-xs text-blue-700">
+      <p className="mt-1 text-base text-blue-700">
         {count} {field.unit} × {perUnit.toLocaleString('zh-TW')} 元 ＝{' '}
         <strong>{total.toLocaleString('zh-TW')} 元</strong>
       </p>
@@ -59,13 +59,13 @@ function InlineFeedback({ field, value }: { field: CardInlineField; value: strin
   const formatted = cap.toLocaleString('zh-TW')
   if (numVal <= cap) {
     return (
-      <p className="mt-1 text-xs text-green-700">
+      <p className="mt-1 text-base text-green-700">
         填入金額在可申報範圍內（上限 {formatted} 元）
       </p>
     )
   }
   return (
-    <p className="mt-1 text-xs text-orange-700">
+    <p className="mt-1 text-base text-orange-700">
       填入金額超過上限；可申報上限為 {formatted} 元
     </p>
   )
@@ -90,7 +90,7 @@ export function ChecklistInlineAmountFields({
     <div className="mt-3 space-y-3 rounded border border-blue-100 bg-blue-50/40 p-3">
       {inlineFields.map((field) => (
         <div key={field.id}>
-          <label className="block text-xs font-medium text-gray-600 mb-1">
+          <label className="block text-base font-medium text-gray-600 mb-1">
             {field.label}（選填）
           </label>
           <div className="flex items-center gap-1.5">
@@ -102,10 +102,13 @@ export function ChecklistInlineAmountFields({
               value={inputValues[field.id] ?? ''}
               onChange={(e) => onInputChange?.(field.id, e.target.value)}
               data-testid={`card-input-${itemId}-${field.id}`}
-              className="w-36 rounded border border-gray-300 px-2 py-1 text-xs text-gray-800 focus:border-blue-400 focus:outline-none"
+              className={[
+                'w-36 rounded border border-gray-300 px-2 py-1 text-base text-gray-800 focus:border-blue-400 focus:outline-none',
+                field.perUnitKey || field.splitPerUnitKeys ? '' : 'no-spin',
+              ].join(' ')}
               placeholder={field.perUnitKey || field.splitPerUnitKeys ? '輸入人數' : '輸入金額'}
             />
-            <span className="text-xs text-gray-500">{field.unit}</span>
+            <span className="text-base text-gray-500">{field.unit}</span>
           </div>
           <InlineFeedback field={field} value={inputValues[field.id] ?? ''} />
         </div>

--- a/src/components/checklist/FormulaRow.tsx
+++ b/src/components/checklist/FormulaRow.tsx
@@ -6,58 +6,83 @@ export interface FormulaItem {
   amount: number | null
 }
 
-export function FormulaRow({ items }: { items: FormulaItem[] }) {
+export function FormulaRow({
+  items,
+  dimFilled = false,
+}: {
+  items: FormulaItem[]
+  dimFilled?: boolean
+}) {
   const filledItems = items.filter((i) => i.amount !== null)
   const emptyItems = items.filter((i) => i.amount === null)
   const partialTotal = filledItems.reduce((s, i) => s + i.amount!, 0)
   const allFilled = emptyItems.length === 0 && filledItems.length > 0
   const anyFilled = filledItems.length > 0
+  const itemRows = items.reduce<FormulaItem[][]>((rows, item, idx) => {
+    const rowIndex = Math.floor(idx / 3)
+    if (!rows[rowIndex]) rows[rowIndex] = []
+    rows[rowIndex].push(item)
+    return rows
+  }, [])
 
   return (
     <div>
-      <div className="flex flex-wrap items-center gap-2">
-        {items.map((item, idx) => (
-          <Fragment key={item.id}>
-            {idx > 0 && (
-              <span className="select-none text-base font-bold text-gray-300">＋</span>
-            )}
-            <div
-              className={`w-[88px] overflow-hidden rounded-lg border-2 transition-all ${
-                item.amount !== null
-                  ? 'border-blue-200 bg-white'
-                  : 'border-dashed border-gray-200 bg-gray-50'
-              }`}
-            >
-              {/* Top: label */}
-              <div
-                className={`border-b px-2 py-1.5 text-center ${
-                  item.amount !== null
-                    ? 'border-blue-100 bg-blue-50/60'
-                    : 'border-dashed border-gray-200 bg-gray-100/40'
-                }`}
-              >
-                <span
-                  className={`text-base font-semibold leading-tight ${
-                    item.amount !== null ? 'text-blue-700' : 'text-gray-400'
+      <div className="space-y-2">
+        {itemRows.map((row, rowIdx) => (
+          <div key={`formula-row-${rowIdx}`} className="flex items-center gap-2">
+            {row.map((item, idx) => (
+              <Fragment key={item.id}>
+                {idx > 0 && (
+                  <span className="select-none text-base font-bold text-gray-300">＋</span>
+                )}
+                <div
+                  className={`checklist-formula-card ${
+                    item.amount !== null
+                      ? (dimFilled ? 'border-gray-300 bg-gray-50' : 'border-blue-200 bg-white')
+                      : 'border-dashed border-gray-200 bg-gray-50'
                   }`}
                 >
-                  {item.label}
-                </span>
-              </div>
-              {/* Bottom: amount */}
-              <div className="flex min-h-[44px] items-center justify-center px-2 py-2 text-center">
-                {item.amount !== null ? (
-                  <span className="text-base font-bold tabular-nums leading-tight text-gray-800">
-                    {item.amount.toLocaleString('zh-TW')}
-                    <br />
-                    <span className="text-xs font-normal text-gray-500">元</span>
-                  </span>
-                ) : (
-                  <span className="text-base leading-tight text-gray-300">未填寫</span>
-                )}
-              </div>
-            </div>
-          </Fragment>
+                  {/* Top: label */}
+                  <div
+                    className={`border-b px-2 py-1.5 text-center ${
+                      item.amount !== null
+                        ? (dimFilled ? 'border-gray-200 bg-gray-100' : 'border-blue-100 bg-blue-50/60')
+                        : 'border-dashed border-gray-200 bg-gray-100/40'
+                    }`}
+                  >
+                    <span
+                      className={`checklist-formula-label text-base font-semibold leading-tight ${
+                        item.amount !== null
+                          ? (dimFilled ? 'text-gray-600' : 'text-blue-700')
+                          : 'text-gray-400'
+                      }`}
+                    >
+                      {item.label}
+                    </span>
+                  </div>
+                  {/* Bottom: amount */}
+                  <div className="flex min-h-[44px] items-center justify-center px-2 py-2 text-center">
+                    {item.amount !== null ? (
+                      <span className="text-base font-bold tabular-nums leading-tight text-gray-800">
+                        {item.amount.toLocaleString('zh-TW')}
+                        <br />
+                        <span className="text-xs font-normal text-gray-500">元</span>
+                      </span>
+                    ) : (
+                      <span className="text-base font-bold leading-tight text-gray-300">
+                        未填寫
+                        <br />
+                        <span className="invisible text-xs font-normal">元</span>
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </Fragment>
+            ))}
+            {rowIdx < itemRows.length - 1 && (
+              <span className="select-none text-base font-bold text-gray-300">＋</span>
+            )}
+          </div>
         ))}
       </div>
 
@@ -73,10 +98,10 @@ export function FormulaRow({ items }: { items: FormulaItem[] }) {
             <span className="text-base font-bold tabular-nums text-orange-500">
               {partialTotal.toLocaleString('zh-TW')} 元
             </span>
-            <span className="text-xs text-orange-400">（{emptyItems.length} 項未填）</span>
+            <span className="text-sm text-orange-400">（{emptyItems.length} 項未填）</span>
           </>
         ) : (
-          <span className="text-xs text-gray-300">待填入</span>
+          <span className="text-sm text-gray-300">待填入</span>
         )}
       </div>
     </div>

--- a/src/components/checklist/FormulaRow.tsx
+++ b/src/components/checklist/FormulaRow.tsx
@@ -37,7 +37,7 @@ export function FormulaRow({ items }: { items: FormulaItem[] }) {
                 }`}
               >
                 <span
-                  className={`text-[11px] font-semibold leading-tight ${
+                  className={`text-base font-semibold leading-tight ${
                     item.amount !== null ? 'text-blue-700' : 'text-gray-400'
                   }`}
                 >
@@ -45,15 +45,15 @@ export function FormulaRow({ items }: { items: FormulaItem[] }) {
                 </span>
               </div>
               {/* Bottom: amount */}
-              <div className="px-2 py-2 text-center">
+              <div className="flex min-h-[44px] items-center justify-center px-2 py-2 text-center">
                 {item.amount !== null ? (
-                  <span className="text-xs font-bold tabular-nums leading-tight text-gray-800">
+                  <span className="text-base font-bold tabular-nums leading-tight text-gray-800">
                     {item.amount.toLocaleString('zh-TW')}
                     <br />
-                    <span className="text-[10px] font-normal text-gray-500">元</span>
+                    <span className="text-xs font-normal text-gray-500">元</span>
                   </span>
                 ) : (
-                  <span className="text-xs leading-tight text-gray-300">未填寫</span>
+                  <span className="text-base leading-tight text-gray-300">未填寫</span>
                 )}
               </div>
             </div>
@@ -63,14 +63,14 @@ export function FormulaRow({ items }: { items: FormulaItem[] }) {
 
       {/* Result row */}
       <div className="mt-3 flex items-baseline gap-1.5">
-        <span className="text-sm font-bold text-gray-400">＝</span>
+        <span className="text-base font-bold text-gray-400">＝</span>
         {allFilled ? (
-          <span className="text-sm font-bold tabular-nums text-green-700">
+          <span className="text-base font-bold tabular-nums text-green-700">
             {partialTotal.toLocaleString('zh-TW')} 元
           </span>
         ) : anyFilled ? (
           <>
-            <span className="text-sm font-bold tabular-nums text-orange-500">
+            <span className="text-base font-bold tabular-nums text-orange-500">
               {partialTotal.toLocaleString('zh-TW')} 元
             </span>
             <span className="text-xs text-orange-400">（{emptyItems.length} 項未填）</span>

--- a/src/components/checklist/StandardItemizedPanel.tsx
+++ b/src/components/checklist/StandardItemizedPanel.tsx
@@ -19,6 +19,9 @@ const SOURCE = {
   url: 'https://download.tax.nat.gov.tw/irx/doc/114%E5%B9%B4%E5%BA%A6%E7%B6%9C%E5%90%88%E6%89%80%E5%BE%97%E7%A8%85%E7%B5%90%E7%AE%97%E7%94%B3%E5%A0%B1%E6%9B%B8%E8%AA%AA%E6%98%8E.pdf',
 }
 
+const PANEL_SHELL_CLASS =
+  'mb-6 rounded-lg border border-gray-200 bg-gray-50 p-4'
+
 // ── Sub-components ────────────────────────────────────────────────────────────
 
 function Verdict({
@@ -36,24 +39,22 @@ function Verdict({
 
   if (allFilled) {
     if (itemizedTotal > standardAmount) {
-      const diff = itemizedTotal - standardAmount
       return (
         <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-semibold text-green-800">
-          列舉較多（+{diff.toLocaleString('zh-TW')} 元）
+          推薦：列舉扣除（列舉扣除 {'>'} 標準扣除）
         </span>
       )
     }
     if (itemizedTotal === standardAmount) {
       return (
         <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600">
-          兩者相同
+          兩者皆可（金額相同）
         </span>
       )
     }
-    const diff = standardAmount - itemizedTotal
     return (
-      <span className="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-800">
-        標準較多（+{diff.toLocaleString('zh-TW')} 元）
+      <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-semibold text-green-800">
+        推薦：標準扣除（標準扣除 {'>'} 列舉扣除）
       </span>
     )
   }
@@ -115,17 +116,13 @@ export function StandardItemizedPanel({ groups, selectedSituations, cardInputMap
   // No itemized items in checklist → show standard deduction only
   if (presentItems.length === 0) {
     return (
-      <section
-        className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4"
-        data-testid="standard-itemized-panel"
-      >
-        <div className="mb-3 flex items-start justify-between gap-2">
-          <p className="text-xs font-medium text-blue-800">標準扣除 vs 列舉扣除</p>
-          <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
-            建議確認
+      <section className={PANEL_SHELL_CLASS} data-testid="standard-itemized-panel">
+        <div className="mb-3">
+          <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-semibold text-green-800">
+            推薦：標準扣除
           </span>
         </div>
-        <p className="text-sm text-gray-700">
+        <p className="text-base text-gray-700">
           114年度標準扣除額為{' '}
           <strong className="font-semibold text-gray-900">
             {standardAmount.toLocaleString('zh-TW')} 元
@@ -150,58 +147,38 @@ export function StandardItemizedPanel({ groups, selectedSituations, cardInputMap
   const anyFilled = filledItems.length > 0
 
   return (
-    <section
-      className="mb-6 rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
-      data-testid="standard-itemized-panel"
-    >
-      {/* Header */}
-      <div className="mb-4 flex items-start justify-between gap-2">
-        <p className="text-xs font-medium text-gray-700">標準扣除 vs 列舉扣除</p>
-        <span className="rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700">
-          建議確認
-        </span>
-      </div>
-
-      {/* Two-column comparison */}
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-        {/* Left: standard deduction — mirrors FormulaRow filled-card style */}
-        <div>
-          <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
-            標準扣除額
-          </p>
-          <div className="inline-block overflow-hidden rounded-lg border-2 border-blue-200 bg-white">
-            <div className="border-b border-blue-100 bg-blue-50/60 px-3 py-1.5 text-center">
-              <span className="text-[11px] font-semibold leading-tight text-blue-700">
-                {isMarried ? '配偶合併申報' : '單身申報'}
-              </span>
-            </div>
-            <div className="px-4 py-2.5 text-center">
-              <span className="text-sm font-bold tabular-nums text-gray-800">
-                {standardAmount.toLocaleString('zh-TW')}
-                <br />
-                <span className="text-[10px] font-normal text-gray-500">元</span>
-              </span>
-            </div>
-          </div>
-        </div>
-
-        {/* Right: itemized deduction formula row */}
-        <div>
-          <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
-            列舉扣除額
-          </p>
-          <FormulaRow items={formulaItems} />
-        </div>
-      </div>
-
-      {/* Verdict */}
-      <div className="mt-4 border-t border-gray-100 pt-3">
+    <section className={PANEL_SHELL_CLASS} data-testid="standard-itemized-panel">
+      <div className="mb-3">
         <Verdict
           standardAmount={standardAmount}
           itemizedTotal={itemizedTotal}
           unfilledCount={unfilledCount}
           anyFilled={anyFilled}
         />
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+            標準扣除額
+          </p>
+          <div className="rounded-lg border border-gray-200 px-4 py-3">
+            <p className="mb-2 text-center text-[11px] font-semibold text-gray-600">
+              {isMarried ? '配偶合併申報' : '單身申報'}
+            </p>
+            <p className="text-center text-base font-bold tabular-nums text-gray-800">
+              {standardAmount.toLocaleString('zh-TW')}
+              <span className="text-[10px] font-normal text-gray-500"> 元</span>
+            </p>
+          </div>
+        </div>
+
+        <div>
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+            列舉扣除額
+          </p>
+          <FormulaRow items={formulaItems} />
+        </div>
       </div>
 
       <SourceFooter />

--- a/src/components/checklist/StandardItemizedPanel.tsx
+++ b/src/components/checklist/StandardItemizedPanel.tsx
@@ -40,20 +40,20 @@ function Verdict({
   if (allFilled) {
     if (itemizedTotal > standardAmount) {
       return (
-        <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-semibold text-green-800">
+        <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-base font-semibold text-green-800">
           推薦：列舉扣除（列舉扣除 {'>'} 標準扣除）
         </span>
       )
     }
     if (itemizedTotal === standardAmount) {
       return (
-        <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600">
-          兩者皆可（金額相同）
+        <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-base font-medium text-gray-600">
+          推薦：標準扣除（金額相同）
         </span>
       )
     }
     return (
-      <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-semibold text-green-800">
+      <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-base font-semibold text-green-800">
         推薦：標準扣除（標準扣除 {'>'} 列舉扣除）
       </span>
     )
@@ -61,14 +61,14 @@ function Verdict({
 
   if (anyFilled) {
     return (
-      <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+      <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-base font-semibold text-amber-800">
         列舉尚有 {unfilledCount} 項未填
       </span>
     )
   }
 
   return (
-    <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-500">
+    <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-base font-medium text-gray-500">
       填入列舉金額後可比較
     </span>
   )
@@ -108,6 +108,7 @@ export function StandardItemizedPanel({ groups, selectedSituations, cardInputMap
   const isMarried = selectedSituations.includes('married')
   const standardKey = isMarried ? 'standard_deduction_married' : 'standard_deduction_single'
   const standardAmount = getNumber(standardKey)
+  const standardTitle = isMarried ? '標準扣除額（配偶合併申報）' : '標準扣除額（單身）'
 
   const presentItems = groups
     .flatMap((g) => g.items)
@@ -118,7 +119,7 @@ export function StandardItemizedPanel({ groups, selectedSituations, cardInputMap
     return (
       <section className={PANEL_SHELL_CLASS} data-testid="standard-itemized-panel">
         <div className="mb-3">
-          <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-semibold text-green-800">
+          <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-base font-semibold text-green-800">
             推薦：標準扣除
           </span>
         </div>
@@ -145,6 +146,12 @@ export function StandardItemizedPanel({ groups, selectedSituations, cardInputMap
   const unfilledCount = formulaItems.length - filledItems.length
   const itemizedTotal = filledItems.reduce((s, i) => s + (i.amount ?? 0), 0)
   const anyFilled = filledItems.length > 0
+  const allFilled = unfilledCount === 0 && anyFilled
+  const recommendedSide: 'standard' | 'itemized' | null = !allFilled
+    ? null
+    : itemizedTotal > standardAmount
+      ? 'itemized'
+      : 'standard'
 
   return (
     <section className={PANEL_SHELL_CLASS} data-testid="standard-itemized-panel">
@@ -159,25 +166,65 @@ export function StandardItemizedPanel({ groups, selectedSituations, cardInputMap
 
       <div className="space-y-4">
         <div>
-          <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+          <p className="mb-2 text-base font-semibold text-gray-400">
             標準扣除額
           </p>
-          <div className="rounded-lg border border-gray-200 px-4 py-3">
-            <p className="mb-2 text-center text-[11px] font-semibold text-gray-600">
-              {isMarried ? '配偶合併申報' : '單身申報'}
-            </p>
-            <p className="text-center text-base font-bold tabular-nums text-gray-800">
-              {standardAmount.toLocaleString('zh-TW')}
-              <span className="text-[10px] font-normal text-gray-500"> 元</span>
-            </p>
+          <div
+            data-testid="standard-deduction-container"
+            className={`rounded-lg border px-4 py-3 ${
+              recommendedSide === 'standard'
+                ? 'border-blue-400 bg-blue-50/30 shadow-sm'
+                : 'border-gray-200'
+            }`}
+          >
+            <div
+              data-testid="standard-deduction-card"
+              className={`checklist-formula-card mx-auto inline-block w-fit ${
+                recommendedSide === 'standard'
+                  ? 'border-blue-200 bg-white'
+                  : 'border-gray-300 bg-gray-50'
+              }`}
+            >
+              <div
+                className={`border-b px-2 py-1.5 text-center ${
+                  recommendedSide === 'standard'
+                    ? 'border-blue-100 bg-blue-50/60'
+                    : 'border-gray-200 bg-gray-100'
+                }`}
+              >
+                <span
+                  className={`checklist-formula-label text-base font-semibold leading-tight ${
+                    recommendedSide === 'standard' ? 'text-blue-700' : 'text-gray-600'
+                  }`}
+                >
+                  {standardTitle}
+                </span>
+              </div>
+              <div className="flex min-h-[44px] items-center justify-center px-2 py-2 text-center">
+                <span className="text-base font-bold tabular-nums leading-tight text-gray-800">
+                  {standardAmount.toLocaleString('zh-TW')}
+                  <br />
+                  <span className="text-xs font-normal text-gray-500">元</span>
+                </span>
+              </div>
+            </div>
           </div>
         </div>
 
         <div>
-          <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+          <p className="mb-2 text-base font-semibold text-gray-400">
             列舉扣除額
           </p>
-          <FormulaRow items={formulaItems} />
+          <div
+            data-testid="itemized-deduction-card"
+            className={`rounded-lg border px-4 py-3 ${
+              recommendedSide === 'itemized'
+                ? 'border-blue-400 bg-blue-50/30 shadow-sm'
+                : 'border-gray-200'
+            }`}
+          >
+            <FormulaRow items={formulaItems} dimFilled={recommendedSide === 'standard'} />
+          </div>
         </div>
       </div>
 

--- a/src/components/tools/AmtTool.tsx
+++ b/src/components/tools/AmtTool.tsx
@@ -33,7 +33,7 @@ export function AmtTool() {
           placeholder="例：1500000"
           value={incomeStr}
           onChange={(e) => setIncomeStr(e.target.value)}
-          className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none sm:max-w-xs"
+          className="no-spin w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none sm:max-w-xs"
         />
       </div>
 

--- a/src/components/tools/CoupleFilingTool.tsx
+++ b/src/components/tools/CoupleFilingTool.tsx
@@ -39,7 +39,7 @@ export function CoupleFilingTool() {
             placeholder="例：800,000"
             value={husbandStr}
             onChange={(e) => setHusbandStr(e.target.value)}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            className="no-spin w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
           />
         </div>
         <div>
@@ -54,7 +54,7 @@ export function CoupleFilingTool() {
             placeholder="例：600,000"
             value={wifeStr}
             onChange={(e) => setWifeStr(e.target.value)}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            className="no-spin w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
           />
         </div>
       </div>

--- a/src/components/tools/DividendTool.tsx
+++ b/src/components/tools/DividendTool.tsx
@@ -45,7 +45,7 @@ export function DividendTool() {
             placeholder="例：500,000"
             value={dividendStr}
             onChange={(e) => setDividendStr(e.target.value)}
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
+            className="no-spin w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-400 focus:outline-none"
           />
         </div>
         <div>

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,10 @@ textarea {
   font-size: 16px;
 }
 
+.print-only {
+  display: none;
+}
+
 @media print {
   @page {
     size: A4;
@@ -31,13 +35,28 @@ textarea {
     display: none !important;
   }
 
+  .print-only {
+    display: block !important;
+  }
+
   .print-container {
     max-width: none !important;
     padding: 0 !important;
   }
 
+  .print-main-layout {
+    display: block !important;
+  }
+
+  .print-summary-card {
+    width: 100% !important;
+    max-width: none !important;
+    margin: 0 !important;
+  }
+
   section,
-  .print-card {
+  .print-card,
+  .print-summary-card {
     break-inside: avoid;
     page-break-inside: avoid;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,15 @@
 @import "tailwindcss";
 
+@layer components {
+  .checklist-formula-card {
+    @apply shrink-0 overflow-hidden rounded-lg border-2 transition-all min-w-[120px];
+  }
+
+  .checklist-formula-label {
+    @apply whitespace-nowrap;
+  }
+}
+
 /*
   Prevent iOS Safari from auto-zooming when tapping inputs.
   font-size must be >= 16px to suppress the behavior.

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,24 @@ textarea {
   font-size: 16px;
 }
 
+button:not(:disabled),
+a[href],
+[role="button"]:not([aria-disabled="true"]) {
+  cursor: pointer;
+}
+
+/* Hide spinner controls for amount inputs only. */
+input.no-spin[type="number"]::-webkit-outer-spin-button,
+input.no-spin[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input.no-spin[type="number"] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
 .print-only {
   display: none;
 }

--- a/src/lib/checklistInputStorage.ts
+++ b/src/lib/checklistInputStorage.ts
@@ -1,0 +1,60 @@
+import type { CardInputMap } from '../types/content'
+import { readLocal, removeLocal, writeLocal } from './storage'
+
+const BASE_STORAGE_KEY = 'tax.checklist.inputs.v1'
+
+export function createChecklistInputStorageKey(basePath: string | undefined = import.meta.env.BASE_URL): string {
+  if (!basePath || basePath === '/') return BASE_STORAGE_KEY
+  return `${BASE_STORAGE_KEY}:${basePath}`
+}
+
+export const CHECKLIST_INPUT_STORAGE_KEY = createChecklistInputStorageKey()
+
+interface SavedChecklistInput {
+  cardInputMap: CardInputMap
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeCardInputMap(input: unknown): CardInputMap {
+  if (!isRecord(input)) return {}
+
+  const normalized: CardInputMap = {}
+  for (const [itemId, fieldValue] of Object.entries(input)) {
+    if (!isRecord(fieldValue)) continue
+
+    const normalizedFieldValues: Record<string, string> = {}
+    for (const [fieldId, value] of Object.entries(fieldValue)) {
+      if (typeof value === 'string') {
+        normalizedFieldValues[fieldId] = value
+      }
+    }
+
+    normalized[itemId] = normalizedFieldValues
+  }
+
+  return normalized
+}
+
+export function loadSavedChecklistInputMap(): CardInputMap {
+  const saved = readLocal<Partial<SavedChecklistInput> | CardInputMap>(CHECKLIST_INPUT_STORAGE_KEY)
+  if (!saved) return {}
+  if ('cardInputMap' in saved) {
+    return normalizeCardInputMap(saved.cardInputMap)
+  }
+  return normalizeCardInputMap(saved)
+}
+
+export function saveChecklistInputMap(cardInputMap: CardInputMap): void {
+  if (Object.keys(cardInputMap).length === 0) {
+    clearSavedChecklistInputMap()
+    return
+  }
+  writeLocal<SavedChecklistInput>(CHECKLIST_INPUT_STORAGE_KEY, { cardInputMap })
+}
+
+export function clearSavedChecklistInputMap(): void {
+  removeLocal(CHECKLIST_INPUT_STORAGE_KEY)
+}

--- a/src/lib/checklistViewStateStorage.ts
+++ b/src/lib/checklistViewStateStorage.ts
@@ -1,0 +1,40 @@
+import { readLocal, removeLocal, writeLocal } from './storage'
+
+const BASE_STORAGE_KEY = 'tax.checklist.view.v1'
+
+export type ChecklistViewState = 'selecting' | 'results'
+
+interface SavedChecklistViewState {
+  page: ChecklistViewState
+}
+
+export function createChecklistViewStateStorageKey(basePath: string | undefined = import.meta.env.BASE_URL): string {
+  if (!basePath || basePath === '/') return BASE_STORAGE_KEY
+  return `${BASE_STORAGE_KEY}:${basePath}`
+}
+
+export const CHECKLIST_VIEW_STATE_STORAGE_KEY = createChecklistViewStateStorageKey()
+
+function normalizeChecklistViewState(input: unknown): ChecklistViewState {
+  if (input === 'results') return 'results'
+  return 'selecting'
+}
+
+export function loadSavedChecklistViewState(): ChecklistViewState {
+  const saved = readLocal<Partial<SavedChecklistViewState> | ChecklistViewState>(CHECKLIST_VIEW_STATE_STORAGE_KEY)
+  if (!saved) return 'selecting'
+  if (typeof saved === 'string') return normalizeChecklistViewState(saved)
+  return normalizeChecklistViewState(saved.page)
+}
+
+export function saveChecklistViewState(page: ChecklistViewState): void {
+  if (page === 'selecting') {
+    clearSavedChecklistViewState()
+    return
+  }
+  writeLocal<SavedChecklistViewState>(CHECKLIST_VIEW_STATE_STORAGE_KEY, { page })
+}
+
+export function clearSavedChecklistViewState(): void {
+  removeLocal(CHECKLIST_VIEW_STATE_STORAGE_KEY)
+}

--- a/src/lib/generalDeductionEffective.ts
+++ b/src/lib/generalDeductionEffective.ts
@@ -13,7 +13,8 @@ export const ITEMIZED_ITEM_IDS = new Set<string>([
 export function parseNum(raw: string): number | null {
   if (raw.trim() === '') return null
   const n = Number(raw.replace(/,/g, ''))
-  return Number.isFinite(n) ? n : null
+  if (!Number.isFinite(n) || n < 0) return null
+  return n
 }
 
 export function getItemizedItemAmount(

--- a/tests/checklist.test.ts
+++ b/tests/checklist.test.ts
@@ -583,23 +583,6 @@ describe('ChecklistResult export panel', () => {
     }),
   )
 
-  it('non-empty result shows copy checklist button', () => {
-    expect(htmlWithResults).toContain('data-testid="copy-checklist-btn"')
-  })
-
-  it('non-empty result shows download checklist button', () => {
-    expect(htmlWithResults).toContain('data-testid="download-checklist-btn"')
-  })
-
-  it('non-empty result shows print or save as PDF button', () => {
-    expect(htmlWithResults).toContain('data-testid="print-checklist-btn"')
-    expect(htmlWithResults).toContain('列印 / 另存 PDF')
-  })
-
-  it('non-empty result shows local-processing notice', () => {
-    expect(htmlWithResults).toContain('瀏覽器中產生')
-  })
-
   it('result page does not show the removed personalized worksheet entry point', () => {
     expect(htmlWithResults).not.toContain('data-testid="open-personalized-page-btn"')
     expect(htmlWithResults).not.toContain('個人化工作表')
@@ -609,10 +592,6 @@ describe('ChecklistResult export panel', () => {
   it('result page does not show the removed income type radio group', () => {
     expect(htmlWithResults).not.toContain('name="income_type"')
     expect(htmlWithResults).not.toContain('你的主要收入來源是？')
-  })
-
-  it('non-empty result shows user-managed storage notice', () => {
-    expect(htmlWithResults).toContain('請自行保管')
   })
 
   it('non-empty result still shows usage reminder', () => {

--- a/tests/checklist.test.ts
+++ b/tests/checklist.test.ts
@@ -392,7 +392,7 @@ describe('ChecklistResult standard vs itemized filing reminder panel', () => {
     expect(html).not.toContain('最划算')
   })
 
-  it('shows 待填入 in the general deduction section when itemized amounts are incomplete', () => {
+  it('keeps the general deduction section header blank when itemized amounts are incomplete', () => {
     const published = CHECKLIST_ITEMS
     const groups = groupByCategory(filterBySituations(published, ['donations']))
     const html = renderToStaticMarkup(
@@ -408,7 +408,7 @@ describe('ChecklistResult standard vs itemized filing reminder panel', () => {
     const generalIdx = html.indexOf('data-testid="checklist-section-general_deductions"')
     expect(generalIdx).toBeGreaterThanOrEqual(0)
     const afterGeneral = html.slice(generalIdx, generalIdx + 800)
-    expect(afterGeneral).toContain('待填入')
+    expect(afterGeneral).not.toContain('待填入')
     expect(html).toContain('前往填寫')
   })
 

--- a/tests/checklist.test.ts
+++ b/tests/checklist.test.ts
@@ -357,6 +357,15 @@ describe('ChecklistResult standard vs itemized filing reminder panel', () => {
     expect(html).toContain('推薦：標準扣除')
     expect(html).not.toContain('建議確認')
     expect(html).not.toContain('標準扣除額（單身）')
+    expect(html).toContain('標準扣除額（配偶合併申報）')
+  })
+
+  it('shows married standard title when itemized cards are present', () => {
+    const html = renderResult(['married', 'donations'])
+    expect(html).toContain('data-testid="standard-itemized-panel"')
+    expect(html).toContain('262,000')
+    expect(html).toContain('標準扣除額（配偶合併申報）')
+    expect(html).not.toContain('標準扣除額（單身）')
   })
 
   it('shows document prompts for selected itemizable situations', () => {
@@ -421,6 +430,98 @@ describe('ChecklistResult standard vs itemized filing reminder panel', () => {
     const afterGeneral = html.slice(generalIdx, generalIdx + 800)
     expect(afterGeneral).toContain('500,000')
     expect(afterGeneral).not.toContain('待填入')
+  })
+
+  it('shows standard method label in summary when standard deduction is used', () => {
+    const html = renderResult(['salary_income'])
+    expect(html).toContain('data-testid="general-deduction-method-label"')
+    expect(html).toContain('標準')
+  })
+
+  it('shows itemized method label in summary when itemized deduction is used', () => {
+    const groups = groupByCategory(filterBySituations(CHECKLIST_ITEMS, ['donations']))
+    const html = renderToStaticMarkup(
+      createElement(ChecklistResult, {
+        groups,
+        totalSelected: 1,
+        selectedSituations: ['donations'],
+        cardInputMap: { 'donations-deduction': { donation_amount: '500000' } },
+        onCardInputChange: () => undefined,
+        onReset: () => undefined,
+      }),
+    )
+    expect(html).toContain('data-testid="general-deduction-method-label"')
+    expect(html).toContain('列舉')
+  })
+
+  it('keeps summary method as standard when itemized total equals standard', () => {
+    const groups = groupByCategory(filterBySituations(CHECKLIST_ITEMS, ['donations']))
+    const html = renderToStaticMarkup(
+      createElement(ChecklistResult, {
+        groups,
+        totalSelected: 1,
+        selectedSituations: ['donations'],
+        cardInputMap: { 'donations-deduction': { donation_amount: '131000' } },
+        onCardInputChange: () => undefined,
+        onReset: () => undefined,
+      }),
+    )
+    expect(html).toContain('推薦：標準扣除（金額相同）')
+    expect(html).toContain('data-testid="general-deduction-method-label"')
+    expect(html).toContain('標準')
+    expect(html).not.toContain('兩者皆可（金額相同）')
+  })
+
+  it('highlights standard card when standard deduction is recommended', () => {
+    const groups = groupByCategory(filterBySituations(CHECKLIST_ITEMS, ['donations']))
+    const html = renderToStaticMarkup(
+      createElement(ChecklistResult, {
+        groups,
+        totalSelected: 1,
+        selectedSituations: ['donations'],
+        cardInputMap: { 'donations-deduction': { donation_amount: '100000' } },
+        onCardInputChange: () => undefined,
+        onReset: () => undefined,
+      }),
+    )
+    expect(html).toContain('data-testid="standard-deduction-container" class="rounded-lg border px-4 py-3 border-blue-400 bg-blue-50/30 shadow-sm"')
+    expect(html).toContain('data-testid="standard-deduction-card" class="checklist-formula-card mx-auto inline-block w-fit border-blue-200 bg-white"')
+    expect(html).toContain('data-testid="itemized-deduction-card" class="rounded-lg border px-4 py-3 border-gray-200"')
+    expect(html).toContain('checklist-formula-card border-gray-300 bg-gray-50')
+  })
+
+  it('highlights itemized card when itemized deduction is recommended', () => {
+    const groups = groupByCategory(filterBySituations(CHECKLIST_ITEMS, ['donations']))
+    const html = renderToStaticMarkup(
+      createElement(ChecklistResult, {
+        groups,
+        totalSelected: 1,
+        selectedSituations: ['donations'],
+        cardInputMap: { 'donations-deduction': { donation_amount: '500000' } },
+        onCardInputChange: () => undefined,
+        onReset: () => undefined,
+      }),
+    )
+    expect(html).toContain('data-testid="itemized-deduction-card" class="rounded-lg border px-4 py-3 border-blue-400 bg-blue-50/30 shadow-sm"')
+    expect(html).toContain('data-testid="standard-deduction-container" class="rounded-lg border px-4 py-3 border-gray-200"')
+    expect(html).toContain('data-testid="standard-deduction-card" class="checklist-formula-card mx-auto inline-block w-fit border-gray-300 bg-gray-50"')
+  })
+
+  it('keeps standard highlight when itemized total equals standard', () => {
+    const groups = groupByCategory(filterBySituations(CHECKLIST_ITEMS, ['donations']))
+    const html = renderToStaticMarkup(
+      createElement(ChecklistResult, {
+        groups,
+        totalSelected: 1,
+        selectedSituations: ['donations'],
+        cardInputMap: { 'donations-deduction': { donation_amount: '131000' } },
+        onCardInputChange: () => undefined,
+        onReset: () => undefined,
+      }),
+    )
+    expect(html).toContain('data-testid="standard-deduction-container" class="rounded-lg border px-4 py-3 border-blue-400 bg-blue-50/30 shadow-sm"')
+    expect(html).toContain('data-testid="standard-deduction-card" class="checklist-formula-card mx-auto inline-block w-fit border-blue-200 bg-white"')
+    expect(html).toContain('data-testid="itemized-deduction-card" class="rounded-lg border px-4 py-3 border-gray-200"')
   })
 })
 

--- a/tests/checklist.test.ts
+++ b/tests/checklist.test.ts
@@ -332,7 +332,8 @@ describe('ChecklistResult standard vs itemized filing reminder panel', () => {
   it('shows the single standard deduction baseline for non-married users', () => {
     const html = renderResult(['salary_income'])
     expect(html).toContain('data-testid="standard-itemized-panel"')
-    expect(html).toContain('標準扣除 vs 列舉扣除')
+    expect(html).toContain('推薦：標準扣除')
+    expect(html).not.toContain('建議確認')
     expect(html).toContain('131,000')
   })
 
@@ -353,7 +354,8 @@ describe('ChecklistResult standard vs itemized filing reminder panel', () => {
     const html = renderResult(['married', 'salary_income'])
     expect(html).toContain('data-testid="standard-itemized-panel"')
     expect(html).toContain('262,000')
-    expect(html).toContain('標準扣除 vs 列舉扣除')
+    expect(html).toContain('推薦：標準扣除')
+    expect(html).not.toContain('建議確認')
     expect(html).not.toContain('標準扣除額（單身）')
   })
 

--- a/tests/generalDeductionEffective.test.ts
+++ b/tests/generalDeductionEffective.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveGeneralDeduction } from '../src/lib/generalDeductionEffective'
+import { getItemizedItemAmount, resolveGeneralDeduction } from '../src/lib/generalDeductionEffective'
 import type { CardInputMap } from '../src/types/content'
 import type { CategoryGroup } from '../src/lib/checklist'
 import type { ChecklistItem } from '../src/types/content'
@@ -115,5 +115,28 @@ describe('resolveGeneralDeduction', () => {
       'donations-deduction': { donation_amount: '400000' },
     }
     expect(resolveGeneralDeduction(groups, partial, false)).toEqual({ status: 'pending_itemized' })
+  })
+
+  it('adds personal insurance and NHI premium without applying per-person cap', () => {
+    expect(
+      getItemizedItemAmount('insurance-deduction', {
+        insurance_personal_amount: '50000',
+        insurance_nhi_amount: '10000',
+      }),
+    ).toBe(60_000)
+  })
+
+  it('treats negative inputs as invalid in itemized formula', () => {
+    expect(
+      getItemizedItemAmount('donations-deduction', {
+        donation_amount: '-1',
+      }),
+    ).toBeNull()
+    expect(
+      getItemizedItemAmount('insurance-deduction', {
+        insurance_personal_amount: '-1',
+        insurance_nhi_amount: '0',
+      }),
+    ).toBeNull()
   })
 })

--- a/tests/situation-single-source-flow.test.tsx
+++ b/tests/situation-single-source-flow.test.tsx
@@ -2,6 +2,8 @@ import { act, createElement } from 'react'
 import { createRoot } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import App from '../src/App'
+import { CHECKLIST_INPUT_STORAGE_KEY } from '../src/lib/checklistInputStorage'
+import { CHECKLIST_VIEW_STATE_STORAGE_KEY } from '../src/lib/checklistViewStateStorage'
 import { SITUATION_SELECTION_STORAGE_KEY } from '../src/lib/situationSelectionStorage'
 
 const LEGACY_MANUAL_OVERRIDES_STORAGE_KEY = 'tax.checklist.manualOverrides.v1'
@@ -180,7 +182,6 @@ describe('situation single-source flow', () => {
     expect(container.textContent).toContain('確認移除此項目')
     expect(container.textContent).not.toContain('會取消第一頁情境')
     clickByTestId('confirm-remove-item-btn')
-    expect(container.textContent).not.toContain('標準扣除額（單身）')
     expect(container.textContent).not.toContain('來源情境：')
     expect(localStorage.getItem(SITUATION_SELECTION_STORAGE_KEY)).toContain('rent')
     expect(localStorage.getItem(SITUATION_SELECTION_STORAGE_KEY)).toContain('donations')
@@ -206,6 +207,22 @@ describe('situation single-source flow', () => {
 
     const marriedSource = container.querySelector<HTMLElement>('[data-testid="card-source-situations-standard-deduction-married"]')
     expect(marriedSource).toBeNull()
+  })
+
+  it('updates standard deduction card title and amount after adding married filing', () => {
+    renderApp()
+    clickButtonByText('薪資收入')
+    clickButtonByText('產生節稅清單')
+    expect(container.textContent).toContain('標準扣除額（單身）')
+    expect(container.textContent).toContain('131,000')
+
+    clickByTestId('open-add-situation-modal-btn')
+    clickByTestId('add-situation-checkbox-married')
+    clickByTestId('confirm-add-situations-btn')
+
+    expect(container.textContent).toContain('標準扣除額（配偶合併申報）')
+    expect(container.textContent).toContain('262,000')
+    expect(container.textContent).not.toContain('標準扣除額（單身）')
   })
 
   it('cancel add in modal does not apply selection', () => {
@@ -239,5 +256,102 @@ describe('situation single-source flow', () => {
     localStorage.setItem(LEGACY_MANUAL_OVERRIDES_STORAGE_KEY, '{"foo":"bar"}')
     renderApp()
     expect(localStorage.getItem(LEGACY_MANUAL_OVERRIDES_STORAGE_KEY)).toBeNull()
+  })
+
+  it('persists checklist input values and restores after reload', () => {
+    const root = renderApp()
+    clickButtonByText('房屋租金支出')
+    clickButtonByText('產生節稅清單')
+    changeInputByTestId('card-input-rent-deduction-rent_amount', '120000')
+
+    const savedRaw = localStorage.getItem(CHECKLIST_INPUT_STORAGE_KEY)
+    expect(savedRaw).toContain('rent-deduction')
+    expect(savedRaw).toContain('120000')
+
+    act(() => {
+      root.unmount()
+    })
+
+    renderApp()
+    const restoredInput = container.querySelector<HTMLInputElement>('[data-testid="card-input-rent-deduction-rent_amount"]')
+    expect(restoredInput?.value).toBe('120000')
+  })
+
+  it('resets checklist data after confirming recalculate', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    renderApp()
+    clickButtonByText('房屋租金支出')
+    clickButtonByText('產生節稅清單')
+    changeInputByTestId('card-input-rent-deduction-rent_amount', '120000')
+
+    clickByTestId('reset-checklist-btn')
+
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(localStorage.getItem(SITUATION_SELECTION_STORAGE_KEY)).toBeNull()
+    expect(localStorage.getItem(CHECKLIST_INPUT_STORAGE_KEY)).toBeNull()
+    expect(container.textContent).toContain('台灣所得稅節稅助理')
+
+    confirmSpy.mockRestore()
+  })
+
+  it('does not reset checklist data when recalculate confirm is cancelled', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    renderApp()
+    clickButtonByText('房屋租金支出')
+    clickButtonByText('產生節稅清單')
+    changeInputByTestId('card-input-rent-deduction-rent_amount', '120000')
+
+    clickByTestId('reset-checklist-btn')
+
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(localStorage.getItem(SITUATION_SELECTION_STORAGE_KEY)).toContain('rent')
+    expect(localStorage.getItem(CHECKLIST_INPUT_STORAGE_KEY)).toContain('120000')
+    expect(container.textContent).toContain('節稅清單')
+
+    confirmSpy.mockRestore()
+  })
+
+  it('keeps results page after refresh when user already generated checklist', () => {
+    const root = renderApp()
+    clickButtonByText('房屋租金支出')
+    clickButtonByText('產生節稅清單')
+
+    expect(container.textContent).toContain('節稅清單')
+    expect(localStorage.getItem(CHECKLIST_VIEW_STATE_STORAGE_KEY)).toContain('results')
+
+    act(() => {
+      root.unmount()
+    })
+
+    renderApp()
+    expect(container.textContent).toContain('節稅清單')
+  })
+
+  it('stays on selecting page after refresh when checklist was not generated', () => {
+    const root = renderApp()
+    clickButtonByText('房屋租金支出')
+    expect(container.textContent).toContain('產生節稅清單')
+    expect(localStorage.getItem(CHECKLIST_VIEW_STATE_STORAGE_KEY)).toBeNull()
+
+    act(() => {
+      root.unmount()
+    })
+
+    renderApp()
+    expect(container.textContent).toContain('產生節稅清單')
+  })
+
+  it('allows spouse salary income to remain 0', () => {
+    renderApp()
+    clickButtonByText('配偶合併申報')
+    clickButtonByText('薪資收入')
+    clickButtonByText('產生節稅清單')
+
+    changeInputByTestId('gross-income-input-self', '300000')
+    changeInputByTestId('gross-income-input-spouse', '0')
+
+    const spouseInput = container.querySelector<HTMLInputElement>('[data-testid="gross-income-input-spouse"]')
+    expect(spouseInput?.value).toBe('0')
+    expect(container.textContent).not.toContain('（1 項未填）')
   })
 })

--- a/tests/situation-single-source-flow.test.tsx
+++ b/tests/situation-single-source-flow.test.tsx
@@ -186,18 +186,17 @@ describe('situation single-source flow', () => {
     expect(localStorage.getItem(SITUATION_SELECTION_STORAGE_KEY)).toContain('donations')
   })
 
-  it('shows situation labels with prefix when the merged exemption item is triggered by multiple income sources', () => {
+  it('hides source situation labels even when items are triggered by income situations', () => {
     renderApp()
     clickButtonByText('薪資收入')
     clickButtonByText('股利收入')
     clickButtonByText('產生節稅清單')
 
     const multiSource = container.querySelector<HTMLElement>('[data-testid="card-source-situations-exemption-general"]')
-    expect(multiSource?.textContent).toContain('情境：薪資收入、股利收入')
-    expect(multiSource?.textContent).not.toContain('來源')
+    expect(multiSource).toBeNull()
 
     const singleSource = container.querySelector<HTMLElement>('[data-testid="card-source-situations-gross-income"]')
-    expect(singleSource?.textContent).toContain('情境：薪資收入')
+    expect(singleSource).toBeNull()
   })
 
   it('hides situation labels for standalone one-to-one situations', () => {


### PR DESCRIPTION
## Summary

- Refines the checklist result and summary experience, including clearer standard-vs-itemized deduction guidance and reduced state ambiguity during completion.
- Moves export actions into the summary area so the flow matches user intent: review outcomes first, then export.
- Adds persistence for key checklist input/view state so context is retained across reloads and repeat visits.
- Improves UI readability and context cues with typography updates, a tax-year badge in the site header, and cleaner general-deduction section labeling.
- Updates related tests and removes outdated export tests to align coverage with the new summary/export behavior.

## Checks

- [x] No personal tax data or private documents included
- [x] Tax-related claims are sourced or marked as draft
- [x] Changes are scoped to this PR
