### PR TITLE
feat: Update cap feedback copy

### DIFF
--- a/ai-context/10-ui-components.md
+++ b/ai-context/10-ui-components.md
@@ -97,6 +97,11 @@ interface Props {
   - `qualified-donation` without gross income: inline prompt `請先填寫 綜合所得總額` with clickable jump to the same `gross_income` section target used by summary "Go fill".
   - `qualified-donation` with gross income but empty value: hint is plain cap copy (`可申報上限為 X 元`) without trailing `20%` suffix text.
   - Any capped amount above cap uses unified red copy: `已達可申報上限 X 元` (shared `CapFeedback` path, not card-specific overrides).
+  - `mortgage-interest` with savings-investment dependency uses a dedicated branch:
+    - The term `儲蓄投資特別扣除額` is rendered as a clickable inline link to the `savings-investment-deduction` card.
+    - Empty value + savings enabled: only `須先扣除「儲蓄投資特別扣除額」`.
+    - Filled value + eligible amount (`input - savings`) below cap: `扣除「儲蓄投資特別扣除額」後為 X 元`.
+    - Filled value + eligible amount above cap: `扣除「儲蓄投資特別扣除額」後已達可申報上限 X 元`.
 - Remove control `no-print` on remove button.
 
 ## `GrossIncomeCard.tsx`

--- a/ai-context/10-ui-components.md
+++ b/ai-context/10-ui-components.md
@@ -93,6 +93,10 @@ interface Props {
 ```
 
 - Composes [`ChecklistCardShell`](../src/components/checklist/ChecklistCardShell.tsx); **`children`** = [`ChecklistInlineAmountFields`](../src/components/checklist/ChecklistInlineAmountFields.tsx) when `inlineFields` non-empty (optional amounts + `capKey` feedback via `getNumber`).
+- `feedbackContext` is forwarded to `ChecklistInlineAmountFields` for contextual rule rendering. Current contextual hooks include:
+  - `qualified-donation` without gross income: inline prompt `請先填寫 綜合所得總額` with clickable jump to the same `gross_income` section target used by summary "Go fill".
+  - `qualified-donation` with gross income but empty value: hint is plain cap copy (`可申報上限為 X 元`) without trailing `20%` suffix text.
+  - Any capped amount above cap uses unified red copy: `已達可申報上限 X 元` (shared `CapFeedback` path, not card-specific overrides).
 - Remove control `no-print` on remove button.
 
 ## `GrossIncomeCard.tsx`

--- a/ai-context/13-testing.md
+++ b/ai-context/13-testing.md
@@ -39,6 +39,11 @@
   - Cap overflow copy is unified as `已達可申報上限 X 元` for all shared capped-field feedback paths.
   - Qualified donation empty-state hint no longer appends `綜合所得總額 20%`.
   - Qualified donation missing-gross prompt asserts the presence of both `請先填寫` and `綜合所得總額` (link text rendered as button content).
+  - Mortgage-interest with savings-investment dependency uses dedicated copy:
+    - `儲蓄投資特別扣除額` is rendered as link text (button) that scrolls to `savings-investment-deduction`.
+    - Empty input: shows only `須先扣除「儲蓄投資特別扣除額」` (no cap prefix).
+    - Filled input, post-deduction amount below cap: `扣除「儲蓄投資特別扣除額」後為 X 元`.
+    - Filled input, post-deduction amount above cap: `扣除「儲蓄投資特別扣除額」後已達可申報上限 X 元`.
 
 ## Integration patterns
 

--- a/ai-context/13-testing.md
+++ b/ai-context/13-testing.md
@@ -35,6 +35,10 @@
 - **Itemized dependencies**:
   - Donations: qualified donations are capped at 20% of `grossIncomeAmount`; if the qualified amount is filled but gross income is missing, itemized line is treated as unfilled (`null`).
   - Mortgage interest: when `savings-investment-deduction` is enabled, mortgage interest subtracts the capped savings-investment deduction first; if savings-investment is enabled but unfilled, subtraction is deferred (treated as 0) so the mortgage line remains responsive.
+- **Inline cap copy contracts** (rendered via `DeductionCard` static markup tests):
+  - Cap overflow copy is unified as `已達可申報上限 X 元` for all shared capped-field feedback paths.
+  - Qualified donation empty-state hint no longer appends `綜合所得總額 20%`.
+  - Qualified donation missing-gross prompt asserts the presence of both `請先填寫` and `綜合所得總額` (link text rendered as button content).
 
 ## Integration patterns
 

--- a/src/components/ChecklistResult.tsx
+++ b/src/components/ChecklistResult.tsx
@@ -434,6 +434,7 @@ export function ChecklistResult({
       grossIncomeAmount,
       savingsInvestmentEnabled,
       savingsInvestmentDeductionAmount,
+      onScrollToSection: handleScrollToSection,
     }),
     [grossIncomeAmount, savingsInvestmentEnabled, savingsInvestmentDeductionAmount],
   )

--- a/src/components/ChecklistResult.tsx
+++ b/src/components/ChecklistResult.tsx
@@ -435,6 +435,7 @@ export function ChecklistResult({
       savingsInvestmentEnabled,
       savingsInvestmentDeductionAmount,
       onScrollToSection: handleScrollToSection,
+      onScrollToItem: handleScrollToItem,
     }),
     [grossIncomeAmount, savingsInvestmentEnabled, savingsInvestmentDeductionAmount],
   )
@@ -457,6 +458,12 @@ export function ChecklistResult({
 
   function handleScrollToSection(categoryId: string) {
     const el = sectionRefs.current[categoryId as CategoryId]
+    if (!el) return
+    animateScrollToY(el.getBoundingClientRect().top + window.scrollY - 80)
+  }
+
+  function handleScrollToItem(itemId: string) {
+    const el = itemRefs.current[itemId]
     if (!el) return
     animateScrollToY(el.getBoundingClientRect().top + window.scrollY - 80)
   }

--- a/src/components/checklist/ChecklistInlineAmountFields.tsx
+++ b/src/components/checklist/ChecklistInlineAmountFields.tsx
@@ -31,7 +31,7 @@ function CapFeedback({
   }
   return (
     <p className="mt-1 text-base text-red-700">
-      可申報上限為 {formatted} 元，超過上限時以上限試算
+      已達可申報上限 {formatted} 元
       {children}
     </p>
   )
@@ -121,18 +121,21 @@ function InlineFeedback({
     const grossIncomeAmount = feedbackContext?.grossIncomeAmount ?? null
     if (grossIncomeAmount === null) {
       return (
-        <p className="mt-1 text-base text-orange-700">
-          需先填寫綜合所得總額，才能計算一般捐贈上限
+        <p className="mt-1 text-base text-gray-700">
+          請先填寫{' '}
+          <button
+            type="button"
+            onClick={() => feedbackContext?.onScrollToSection?.('gross_income')}
+            className="font-medium text-blue-700 hover:text-blue-800 hover:underline underline-offset-2 transition-colors"
+          >
+            綜合所得總額
+          </button>
         </p>
       )
     }
     const cap = grossIncomeAmount * 0.2
     if (!hasValue) {
-      return (
-        <CapHint cap={cap}>
-          （綜合所得總額 20%）
-        </CapHint>
-      )
+      return <CapHint cap={cap} />
     }
     const numVal = parseAmount(value)
     if (numVal === null || numVal <= 0) return null

--- a/src/components/checklist/ChecklistInlineAmountFields.tsx
+++ b/src/components/checklist/ChecklistInlineAmountFields.tsx
@@ -56,6 +56,16 @@ function InlineFeedback({
   feedbackContext?: Partial<CardInlineFeedbackContext>
 }) {
   const hasValue = value.trim() !== ''
+  const savingsTargetItemId = 'savings-investment-deduction'
+  const savingsLink = (
+    <button
+      type="button"
+      onClick={() => feedbackContext?.onScrollToItem?.(savingsTargetItemId)}
+      className="font-medium text-blue-700 hover:text-blue-800 hover:underline underline-offset-2 transition-colors"
+    >
+      儲蓄投資特別扣除額
+    </button>
+  )
 
   if (field.splitPerUnitKeys) {
     if (!hasValue) return null
@@ -154,25 +164,37 @@ function InlineFeedback({
       ? (feedbackContext.savingsInvestmentDeductionAmount ?? 0)
       : 0
     if (!hasValue) {
+      if (feedbackContext?.savingsInvestmentEnabled) {
+        return (
+          <p className="mt-1 text-base text-blue-700">
+            須先扣除「{savingsLink}」
+          </p>
+        )
+      }
       return (
-        <CapHint cap={cap}>
-          {feedbackContext?.savingsInvestmentEnabled ? (
-            <>；須先扣除儲蓄投資扣除額</>
-          ) : null}
-        </CapHint>
+        <CapHint cap={cap} />
       )
     }
     const numVal = parseAmount(value)
     if (numVal === null || numVal <= 0) return null
     const eligibleAmount = Math.max(0, numVal - savingsDeduction)
 
-    return (
-      <CapFeedback value={eligibleAmount} cap={cap}>
-        {savingsDeduction > 0 ? (
-          <>；扣除儲蓄投資扣除額後為 {formatAmount(eligibleAmount)} 元</>
-        ) : null}
-      </CapFeedback>
-    )
+    if (savingsDeduction > 0 && eligibleAmount <= cap) {
+      return (
+        <p className="mt-1 text-base text-green-700">
+          扣除「{savingsLink}」後為 {formatAmount(eligibleAmount)} 元
+        </p>
+      )
+    }
+    if (savingsDeduction > 0 && eligibleAmount > cap) {
+      return (
+        <p className="mt-1 text-base text-red-700">
+          扣除「{savingsLink}」後已達可申報上限 {formatAmount(cap)} 元
+        </p>
+      )
+    }
+
+    return <CapFeedback value={eligibleAmount} cap={cap} />
   }
 
   if (!field.capKey) return null

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -73,6 +73,7 @@ export interface CardInlineFeedbackContext {
   grossIncomeAmount: number | null
   savingsInvestmentEnabled: boolean
   savingsInvestmentDeductionAmount: number | null
+  onScrollToSection?: (categoryId: string) => void
 }
 
 export type CardInputMap = Record<string, Record<string, string>>

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -74,6 +74,7 @@ export interface CardInlineFeedbackContext {
   savingsInvestmentEnabled: boolean
   savingsInvestmentDeductionAmount: number | null
   onScrollToSection?: (categoryId: string) => void
+  onScrollToItem?: (itemId: string) => void
 }
 
 export type CardInputMap = Record<string, Record<string, string>>

--- a/tests/checklist.test.ts
+++ b/tests/checklist.test.ts
@@ -889,7 +889,7 @@ describe('DeductionCard inline input fields', () => {
       }),
     )
     expect(html).toContain('text-red-700')
-    expect(html).toContain('可申報上限為 218,000 元，超過上限時以上限試算')
+    expect(html).toContain('已達可申報上限 218,000 元')
   })
 
   it('shows cap hint when capped field is empty', () => {
@@ -924,7 +924,7 @@ describe('DeductionCard inline input fields', () => {
       }),
     )
     expect(html).toContain('text-red-700')
-    expect(html).toContain('可申報上限為 200,000 元，超過上限時以上限試算')
+    expect(html).toContain('已達可申報上限 200,000 元')
   })
 
   it('shows qualified donation cap hint before input when gross income exists', () => {
@@ -937,7 +937,7 @@ describe('DeductionCard inline input fields', () => {
       }),
     )
     expect(html).toContain('可申報上限為 200,000 元')
-    expect(html).toContain('綜合所得總額 20%')
+    expect(html).not.toContain('綜合所得總額 20%')
   })
 
   it('asks for gross income before qualified donation cap can be judged', () => {
@@ -949,7 +949,8 @@ describe('DeductionCard inline input fields', () => {
         feedbackContext: { grossIncomeAmount: null },
       }),
     )
-    expect(html).toContain('需先填寫綜合所得總額，才能計算一般捐贈上限')
+    expect(html).toContain('請先填寫')
+    expect(html).toContain('綜合所得總額')
   })
 
   it('shows no-limit feedback for government donations', () => {
@@ -987,7 +988,7 @@ describe('DeductionCard inline input fields', () => {
       }),
     )
     expect(html).toContain('text-red-700')
-    expect(html).toContain('可申報上限為 300,000 元，超過上限時以上限試算')
+    expect(html).toContain('已達可申報上限 300,000 元')
     expect(html).toContain('扣除儲蓄投資扣除額後為 350,000 元')
   })
 

--- a/tests/checklist.test.ts
+++ b/tests/checklist.test.ts
@@ -988,8 +988,27 @@ describe('DeductionCard inline input fields', () => {
       }),
     )
     expect(html).toContain('text-red-700')
-    expect(html).toContain('已達可申報上限 300,000 元')
-    expect(html).toContain('扣除儲蓄投資扣除額後為 350,000 元')
+    expect(html).toContain('扣除「')
+    expect(html).toContain('儲蓄投資特別扣除額')
+    expect(html).toContain('」後已達可申報上限 300,000 元')
+  })
+
+  it('shows mortgage interest net eligible amount when below cap after savings deduction', () => {
+    const html = renderToStaticMarkup(
+      createElement(DeductionCard, {
+        item: makeItem(),
+        inlineFields: [mortgageInterestField],
+        inputValues: { mortgage_interest_amount: '210111' },
+        feedbackContext: {
+          savingsInvestmentEnabled: true,
+          savingsInvestmentDeductionAmount: 100_000,
+        },
+      }),
+    )
+    expect(html).toContain('text-green-700')
+    expect(html).toContain('扣除「')
+    expect(html).toContain('儲蓄投資特別扣除額')
+    expect(html).toContain('」後為 110,111 元')
   })
 
   it('shows mortgage interest cap hint before input', () => {
@@ -1001,8 +1020,10 @@ describe('DeductionCard inline input fields', () => {
         feedbackContext: { savingsInvestmentEnabled: true },
       }),
     )
-    expect(html).toContain('可申報上限為 300,000 元')
-    expect(html).toContain('須先扣除儲蓄投資扣除額')
+    expect(html).toContain('須先扣除「')
+    expect(html).toContain('儲蓄投資特別扣除額')
+    expect(html).toContain('」')
+    expect(html).not.toContain('可申報上限為 300,000 元')
   })
 
   it('shows privacy notice when inlineFields is non-empty', () => {


### PR DESCRIPTION
## Summary

- Unifies capped-field overflow feedback copy across shared inline feedback logic to `已達可申報上限 X 元`.
- Updates qualified donation messaging:
  - Missing gross income now shows `請先填寫 綜合所得總額` with a clickable jump to the same `gross_income` section used by the summary panel.
  - Empty-state hint keeps only `可申報上限為 X 元` and removes the `(綜合所得總額 20%)` suffix.
- Extends feedback context typing and wiring to pass section-scroll callback into inline field feedback.
- Updates tests and AI context docs to match the new copy and interaction contract.


## Checks

- [x] No personal tax data or private documents included
- [x] Tax-related claims are sourced or marked as draft
- [x] Changes are scoped to this PR
