### PR TITLE
fix(flow): route intro and header navigation by existing selection state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -148,11 +148,18 @@ function getItemSourceSituationLabelsById(
 
 function App() {
   const [selected, setSelected] = useState<SituationId[]>(() => loadSavedSituationSelection(SITUATION_IDS))
+  const [hasGeneratedChecklist, setHasGeneratedChecklist] = useState<boolean>(() => {
+    const savedViewState = loadSavedChecklistViewState()
+    const savedSelection = loadSavedSituationSelection(SITUATION_IDS)
+    return savedViewState === 'results' && savedSelection.length > 0
+  })
   const [appState, setAppState] = useState<AppState>(() => {
     const savedViewState = loadSavedChecklistViewState()
     const savedSelection = loadSavedSituationSelection(SITUATION_IDS)
+    const generated = savedViewState === 'results' && savedSelection.length > 0
+    if (generated) return 'results'
+    if (savedSelection.length > 0) return 'selecting'
     if (savedViewState === 'intro') return 'intro'
-    if (savedSelection.length > 0) return 'results'
     return 'intro'
   })
   const [cardInputMap, setCardInputMap] = useState<CardInputMap>(() => loadSavedChecklistInputMap())
@@ -169,8 +176,8 @@ function App() {
   }, [cardInputMap])
 
   useEffect(() => {
-    saveChecklistViewState(appState)
-  }, [appState])
+    saveChecklistViewState(hasGeneratedChecklist ? 'results' : 'selecting')
+  }, [hasGeneratedChecklist])
 
   useEffect(() => {
     // Clean up deprecated pre-v2 checklist overrides data to keep refresh behavior deterministic.
@@ -183,8 +190,8 @@ function App() {
         const syncedSelection = parseSavedSituationSelection(event.newValue, SITUATION_IDS)
         setSelected(syncedSelection)
         if (syncedSelection.length === 0) {
+          setHasGeneratedChecklist(false)
           setAppState('selecting')
-          saveChecklistViewState('selecting')
         }
       }
     }
@@ -203,20 +210,18 @@ function App() {
   function handleGenerate() {
     if (selected.length > 0) {
       setScrollToItemId(null)
+      setHasGeneratedChecklist(true)
       setAppState('results')
-      saveChecklistViewState('results')
       window.scrollTo(0, 0)
     }
   }
 
   function navigateToChecklistFlow() {
     setScrollToItemId(null)
-    if (selected.length > 0) {
+    if (hasGeneratedChecklist && selected.length > 0) {
       setAppState('results')
-      saveChecklistViewState('results')
     } else {
       setAppState('selecting')
-      saveChecklistViewState('selecting')
     }
     window.scrollTo(0, 0)
   }
@@ -224,12 +229,12 @@ function App() {
   function navigateToIntro() {
     setScrollToItemId(null)
     setAppState('intro')
-    saveChecklistViewState('intro')
     window.scrollTo(0, 0)
   }
 
   function resetChecklistState() {
     setSelected([])
+    setHasGeneratedChecklist(false)
     setAppState('selecting')
     setCardInputMap({})
     setPendingRemovalEffect(null)
@@ -286,8 +291,8 @@ function App() {
     setCardInputMap((prev) => omitIdsFromCardInputMap(prev, [effect.itemId]))
     if (nextSelected.length === 0) {
       setScrollToItemId(null)
+      setHasGeneratedChecklist(false)
       setAppState('selecting')
-      saveChecklistViewState('selecting')
       window.scrollTo(0, 0)
     }
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -152,8 +152,7 @@ function App() {
     const savedViewState = loadSavedChecklistViewState()
     const savedSelection = loadSavedSituationSelection(SITUATION_IDS)
     if (savedViewState === 'intro') return 'intro'
-    if (savedViewState === 'results' && savedSelection.length > 0) return 'results'
-    if (savedSelection.length > 0) return 'selecting'
+    if (savedSelection.length > 0) return 'results'
     return 'intro'
   })
   const [cardInputMap, setCardInputMap] = useState<CardInputMap>(() => loadSavedChecklistInputMap())
@@ -208,6 +207,25 @@ function App() {
       saveChecklistViewState('results')
       window.scrollTo(0, 0)
     }
+  }
+
+  function navigateToChecklistFlow() {
+    setScrollToItemId(null)
+    if (selected.length > 0) {
+      setAppState('results')
+      saveChecklistViewState('results')
+    } else {
+      setAppState('selecting')
+      saveChecklistViewState('selecting')
+    }
+    window.scrollTo(0, 0)
+  }
+
+  function navigateToIntro() {
+    setScrollToItemId(null)
+    setAppState('intro')
+    saveChecklistViewState('intro')
+    window.scrollTo(0, 0)
   }
 
   function resetChecklistState() {
@@ -314,7 +332,7 @@ function App() {
     const itemSourceSituationLabelsById = getItemSourceSituationLabelsById(selected, effectiveItems)
 
     if (appState === 'intro') {
-      return <IntroPage onStart={() => setAppState('selecting')} />
+      return <IntroPage onStart={navigateToChecklistFlow} />
     }
 
     if (appState === 'results') {
@@ -354,8 +372,8 @@ function App() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <SiteHeader
         currentFeatureId="tax-checklist"
-        onHome={() => setAppState('intro')}
-        onNavClick={() => setAppState('selecting')}
+        onHome={navigateToIntro}
+        onNavClick={() => navigateToChecklistFlow()}
       />
       <main className="flex-1">
         {content}

--- a/tests/situation-selection-storage.test.tsx
+++ b/tests/situation-selection-storage.test.tsx
@@ -35,11 +35,13 @@ function renderApp() {
   return root
 }
 
-function clickByTestId(testId: string) {
-  const element = container.querySelector<HTMLElement>(`[data-testid="${testId}"]`)
-  if (!element) throw new Error(`Missing element with data-testid "${testId}"`)
+function clickButtonByText(text: string) {
+  const button = Array.from(container.querySelectorAll('button')).find((el) =>
+    el.textContent?.includes(text),
+  )
+  if (!button) throw new Error(`Missing button with text "${text}"`)
   act(() => {
-    element.click()
+    button.click()
   })
 }
 
@@ -73,7 +75,7 @@ describe('situation selection storage', () => {
     expect(parseSavedSituationSelection('not-json', allowedIds)).toEqual([])
   })
 
-  it('clears page selection and browser storage from the results page reset flow', () => {
+  it('clears page selection and browser storage from selecting page', () => {
     localStorage.setItem(
       SITUATION_SELECTION_STORAGE_KEY,
       JSON.stringify({ selected: ['rent', 'salary_income'] }),
@@ -81,11 +83,10 @@ describe('situation selection storage', () => {
 
     renderApp()
 
-    expect(container.textContent).toContain('節稅試算清單')
+    expect(container.textContent).toContain('選擇符合 114 年度的報稅項目')
     expect(localStorage.getItem(SITUATION_SELECTION_STORAGE_KEY)).not.toBeNull()
 
-    clickByTestId('reset-checklist-btn')
-    clickByTestId('confirm-reset-btn')
+    clickButtonByText('清空')
 
     expect(container.textContent).toContain('請先選擇至少一項情況')
     expect(localStorage.getItem(SITUATION_SELECTION_STORAGE_KEY)).toBeNull()

--- a/tests/situation-selection-storage.test.tsx
+++ b/tests/situation-selection-storage.test.tsx
@@ -35,13 +35,11 @@ function renderApp() {
   return root
 }
 
-function clickButtonByText(text: string) {
-  const button = Array.from(container.querySelectorAll('button')).find((el) =>
-    el.textContent?.includes(text),
-  )
-  if (!button) throw new Error(`Missing button with text "${text}"`)
+function clickByTestId(testId: string) {
+  const element = container.querySelector<HTMLElement>(`[data-testid="${testId}"]`)
+  if (!element) throw new Error(`Missing element with data-testid "${testId}"`)
   act(() => {
-    button.click()
+    element.click()
   })
 }
 
@@ -75,7 +73,7 @@ describe('situation selection storage', () => {
     expect(parseSavedSituationSelection('not-json', allowedIds)).toEqual([])
   })
 
-  it('clears page selection and browser storage from the first page', () => {
+  it('clears page selection and browser storage from the results page reset flow', () => {
     localStorage.setItem(
       SITUATION_SELECTION_STORAGE_KEY,
       JSON.stringify({ selected: ['rent', 'salary_income'] }),
@@ -83,10 +81,11 @@ describe('situation selection storage', () => {
 
     renderApp()
 
-    expect(container.textContent).toContain('已選 ')
+    expect(container.textContent).toContain('節稅試算清單')
     expect(localStorage.getItem(SITUATION_SELECTION_STORAGE_KEY)).not.toBeNull()
 
-    clickButtonByText('清空')
+    clickByTestId('reset-checklist-btn')
+    clickByTestId('confirm-reset-btn')
 
     expect(container.textContent).toContain('請先選擇至少一項情況')
     expect(localStorage.getItem(SITUATION_SELECTION_STORAGE_KEY)).toBeNull()

--- a/tests/situation-single-source-flow.test.tsx
+++ b/tests/situation-single-source-flow.test.tsx
@@ -159,20 +159,17 @@ function changeInputByTestId(testId: string, value: string) {
 }
 
 describe('situation single-source flow', () => {
-  it('goes to results from intro start button when a saved selection exists', () => {
-    localStorage.setItem(
-      SITUATION_SELECTION_STORAGE_KEY,
-      JSON.stringify({ selected: ['rent'] }),
-    )
-    localStorage.setItem(
-      CHECKLIST_VIEW_STATE_STORAGE_KEY,
-      JSON.stringify({ page: 'intro' }),
-    )
-
+  it('goes to selecting from intro start button when a selection exists but checklist is not generated', () => {
     renderApp({ autoStart: false })
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: SITUATION_SELECTION_STORAGE_KEY,
+        newValue: JSON.stringify({ selected: ['rent'] }),
+      }))
+    })
     clickButtonByText('開始試算')
 
-    expect(container.textContent).toContain('節稅試算清單')
+    expect(container.textContent).toContain('選擇符合 114 年度的報稅項目')
   })
 
   it('goes to selecting from intro start button when no selection exists', () => {
@@ -182,20 +179,16 @@ describe('situation single-source flow', () => {
     expect(container.textContent).toContain('選擇符合 114 年度的報稅項目')
   })
 
-  it('goes to results from header nav when a saved selection exists', () => {
+  it('goes to selecting from header nav when a saved selection exists but checklist is not generated', () => {
     localStorage.setItem(
       SITUATION_SELECTION_STORAGE_KEY,
       JSON.stringify({ selected: ['rent'] }),
-    )
-    localStorage.setItem(
-      CHECKLIST_VIEW_STATE_STORAGE_KEY,
-      JSON.stringify({ page: 'intro' }),
     )
 
     renderApp({ autoStart: false })
     clickButtonByText('節稅試算')
 
-    expect(container.textContent).toContain('節稅試算清單')
+    expect(container.textContent).toContain('選擇符合 114 年度的報稅項目')
   })
 
   it('goes to selecting from header nav when no selection exists', () => {
@@ -203,6 +196,28 @@ describe('situation single-source flow', () => {
     clickButtonByText('節稅試算')
 
     expect(container.textContent).toContain('選擇符合 114 年度的報稅項目')
+  })
+
+  it('goes to results from intro start button after checklist has been generated', () => {
+    renderApp({ autoStart: false })
+    clickButtonByText('開始試算')
+    clickButtonByText('薪資收入')
+    clickButtonByText('產生節稅清單')
+    clickButtonByText('台灣節稅資訊平台')
+    clickButtonByText('開始試算')
+
+    expect(container.textContent).toContain('節稅試算清單')
+  })
+
+  it('goes to results from header nav after checklist has been generated and user returns to intro', () => {
+    renderApp({ autoStart: false })
+    clickButtonByText('開始試算')
+    clickButtonByText('薪資收入')
+    clickButtonByText('產生節稅清單')
+    clickButtonByText('台灣節稅資訊平台')
+    clickButtonByText('節稅試算')
+
+    expect(container.textContent).toContain('節稅試算清單')
   })
 
   it('scrolls to top when navigating via header nav button', () => {
@@ -491,7 +506,7 @@ describe('situation single-source flow', () => {
     expect(container.textContent).toContain('節稅試算清單')
   })
 
-  it('returns to results page after refresh when a selection already exists', () => {
+  it('returns to selecting page after refresh when a selection exists but checklist was not generated', () => {
     const root = renderApp()
     clickButtonByText('房屋租金支出')
     expect(container.textContent).toContain('產生節稅清單')
@@ -502,7 +517,7 @@ describe('situation single-source flow', () => {
     })
 
     renderApp()
-    expect(container.textContent).toContain('節稅試算清單')
+    expect(container.textContent).toContain('選擇符合 114 年度的報稅項目')
   })
 
   it('allows spouse salary income to remain 0', () => {

--- a/tests/situation-single-source-flow.test.tsx
+++ b/tests/situation-single-source-flow.test.tsx
@@ -112,18 +112,20 @@ afterEach(() => {
   document.body.removeChild(container)
 })
 
-function renderApp() {
+function renderApp({ autoStart = true }: { autoStart?: boolean } = {}) {
   const root = createRoot(container)
   act(() => {
     root.render(createElement(App))
   })
-  const introButton = Array.from(container.querySelectorAll('button')).find(
-    (el) => el.textContent?.trim() === '開始試算',
-  )
-  if (introButton) {
-    act(() => {
-      introButton.click()
-    })
+  if (autoStart) {
+    const introButton = Array.from(container.querySelectorAll('button')).find(
+      (el) => el.textContent?.trim() === '開始試算',
+    )
+    if (introButton) {
+      act(() => {
+        introButton.click()
+      })
+    }
   }
   return root
 }
@@ -157,6 +159,62 @@ function changeInputByTestId(testId: string, value: string) {
 }
 
 describe('situation single-source flow', () => {
+  it('goes to results from intro start button when a saved selection exists', () => {
+    localStorage.setItem(
+      SITUATION_SELECTION_STORAGE_KEY,
+      JSON.stringify({ selected: ['rent'] }),
+    )
+    localStorage.setItem(
+      CHECKLIST_VIEW_STATE_STORAGE_KEY,
+      JSON.stringify({ page: 'intro' }),
+    )
+
+    renderApp({ autoStart: false })
+    clickButtonByText('開始試算')
+
+    expect(container.textContent).toContain('節稅試算清單')
+  })
+
+  it('goes to selecting from intro start button when no selection exists', () => {
+    renderApp({ autoStart: false })
+    clickButtonByText('開始試算')
+
+    expect(container.textContent).toContain('選擇符合 114 年度的報稅項目')
+  })
+
+  it('goes to results from header nav when a saved selection exists', () => {
+    localStorage.setItem(
+      SITUATION_SELECTION_STORAGE_KEY,
+      JSON.stringify({ selected: ['rent'] }),
+    )
+    localStorage.setItem(
+      CHECKLIST_VIEW_STATE_STORAGE_KEY,
+      JSON.stringify({ page: 'intro' }),
+    )
+
+    renderApp({ autoStart: false })
+    clickButtonByText('節稅試算')
+
+    expect(container.textContent).toContain('節稅試算清單')
+  })
+
+  it('goes to selecting from header nav when no selection exists', () => {
+    renderApp({ autoStart: false })
+    clickButtonByText('節稅試算')
+
+    expect(container.textContent).toContain('選擇符合 114 年度的報稅項目')
+  })
+
+  it('scrolls to top when navigating via header nav button', () => {
+    renderApp({ autoStart: false })
+    act(() => {
+      window.scrollTo(0, 420)
+    })
+
+    clickButtonByText('節稅試算')
+    expect(scrollToSpy).toHaveBeenLastCalledWith(0, 0)
+  })
+
   it('supports grouped situation add modal and removes only the target card', () => {
     renderApp()
     clickButtonByText('薪資收入')
@@ -433,7 +491,7 @@ describe('situation single-source flow', () => {
     expect(container.textContent).toContain('節稅試算清單')
   })
 
-  it('stays on selecting page after refresh when checklist was not generated', () => {
+  it('returns to results page after refresh when a selection already exists', () => {
     const root = renderApp()
     clickButtonByText('房屋租金支出')
     expect(container.textContent).toContain('產生節稅清單')
@@ -444,7 +502,7 @@ describe('situation single-source flow', () => {
     })
 
     renderApp()
-    expect(container.textContent).toContain('產生節稅清單')
+    expect(container.textContent).toContain('節稅試算清單')
   })
 
   it('allows spouse salary income to remain 0', () => {


### PR DESCRIPTION
## Summary

- Extract shared navigation helpers for intro and header entry points
- Navigate to results when selections exist, otherwise go to selecting
- Keep scroll-to-top and checklist view-state persistence consistent
- Update reset-flow test and add coverage for intro/header and refresh behavior 

## Checks

- [x] No personal tax data or private documents included
- [x] Tax-related claims are sourced or marked as draft
- [x] Changes are scoped to this PR
