### PR TITLE
fix(flow): route intro and header navigation by existing selection state

### DIFF
--- a/src/components/ChecklistResult.tsx
+++ b/src/components/ChecklistResult.tsx
@@ -406,7 +406,7 @@ function SavingsInvestmentDeductionCard({
             <span>利息收入合計</span>
             <span className="tabular-nums">{formatTwd(interestIncomeAmount)} 元</span>
           </div>
-          <div className="flex justify-between gap-4 font-semibold text-green-700">
+          <div className="flex justify-between gap-4 font-semibold text-blue-700">
             <span>可扣除金額</span>
             <span className="tabular-nums">{formatTwd(deduction)} 元</span>
           </div>
@@ -946,6 +946,7 @@ export function ChecklistResult({
             {groups.map((group) => (
               <section
                 key={group.category}
+                id={group.category}
                 ref={(element) => {
                   sectionRefs.current[group.category] = element
                 }}
@@ -956,7 +957,7 @@ export function ChecklistResult({
                   {(() => {
                     const sub = getSectionSubtotal(group)
                     return sub !== null ? (
-                      <span className="text-base font-semibold text-green-700 tabular-nums">
+                      <span className="text-[20px] font-semibold text-blue-700 tabular-nums">
                         {sub.toLocaleString('zh-TW')} 元
                       </span>
                     ) : null
@@ -999,6 +1000,7 @@ export function ChecklistResult({
                   {group.items.map((item) => (
                     <div
                       key={item.id}
+                      id={item.id}
                       ref={(element) => {
                         itemRefs.current[item.id] = element
                       }}

--- a/src/components/IncomeCard.tsx
+++ b/src/components/IncomeCard.tsx
@@ -74,7 +74,7 @@ function PersonRow({
   const hasSalaryFormula = config.kind === 'salary' && person.hasInput && income > 0
 
   return (
-    <div className="border-b border-blue-100 py-3 first:pt-0 last:border-0 last:pb-0">
+    <div className="border-b border-gray-300 py-3 first:pt-0 last:border-0 last:pb-0">
       <div className="mb-1.5 flex items-center gap-2">
         {isFixed ? (
           <span className="min-w-[3rem] text-base font-semibold text-gray-700">{person.label}</span>
@@ -211,7 +211,7 @@ export function IncomeCard({
         </p>
       )}
 
-      <div className="space-y-0 rounded border border-blue-100 bg-blue-50/40 p-3">
+      <div className="space-y-0 rounded-xl border border-gray-300 bg-gray-100/70 p-3">
         {persons.map((person) => {
           const isFixed = person.id === 'self' || person.id === 'spouse'
           const extraOrder =
@@ -253,7 +253,7 @@ export function IncomeCard({
       <div className="mt-3 space-y-0.5 text-base text-gray-500">
         <p className="font-medium text-gray-700">{config.subtotalLabel}</p>
         {isComplete ? (
-          <div className="flex justify-between gap-4 border-t border-gray-100 pt-0.5 font-semibold text-green-700" data-testid={`income-total-${config.id}`}>
+          <div className="flex justify-between gap-4 border-t border-gray-100 pt-0.5 font-semibold text-blue-700" data-testid={`income-total-${config.id}`}>
             <span>＝</span>
             <span className="tabular-nums">{formatTwd(total)} 元</span>
           </div>

--- a/src/components/TaxSummaryPanel.tsx
+++ b/src/components/TaxSummaryPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import { calcTax, getBrackets } from '../lib/numbers'
 import { Card, CardBody, CardHeader } from './ui/Card'
 
@@ -30,6 +31,30 @@ function GoFill({ sectionId, onScroll }: { sectionId: string; onScroll?: (id: st
     >
       前往填寫
     </button>
+  )
+}
+
+function SummarySectionLink({
+  sectionId,
+  onScroll,
+  children,
+}: {
+  sectionId: string
+  onScroll?: (id: string) => void
+  children: ReactNode
+}) {
+  return (
+    <a
+      href={`#${sectionId}`}
+      onClick={(event) => {
+        if (!onScroll) return
+        event.preventDefault()
+        onScroll(sectionId)
+      }}
+      className="text-gray-600 hover:text-gray-800 hover:underline underline-offset-2"
+    >
+      {children}
+    </a>
   )
 }
 
@@ -82,21 +107,27 @@ function TaxFormulaDialog({ onClose }: { onClose: () => void }) {
     return () => { document.body.style.overflow = '' }
   }, [])
 
-  return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-gray-900/40 p-4">
-      <div className="w-full max-w-2xl flex flex-col max-h-[calc(100dvh-2rem)] rounded-xl border border-gray-200 bg-white shadow-2xl">
-        <div className="flex items-center justify-between border-b border-gray-100 px-5 py-3.5">
+  const dialog = (
+    <div
+      data-testid="tax-formula-dialog-overlay"
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-gray-900/40 p-4 no-print"
+    >
+      <div
+        data-testid="tax-formula-dialog"
+        className="w-full max-w-2xl flex flex-col max-h-[calc(100dvh-2rem)] rounded-xl border border-gray-200 bg-white shadow-xl"
+      >
+        <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
           <h2 className="text-base font-semibold text-gray-900">「所得稅應納稅額」公式</h2>
           <button
             type="button"
             onClick={onClose}
             aria-label="關閉"
-            className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-gray-200 text-base text-gray-500 hover:border-gray-300 hover:bg-gray-100 transition-colors"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-gray-200 text-sm text-gray-500 hover:border-gray-300 hover:bg-gray-100"
           >
             ×
           </button>
         </div>
-        <div className="flex-1 min-h-0 overflow-y-auto px-5 py-4">
+        <div className="flex-1 min-h-0 overflow-y-auto px-4 py-4">
           <p className="text-base text-gray-700 mb-4">
             公式：<span className="font-semibold text-gray-900">「綜合所得淨額」× 稅率 − 累進差額</span>
           </p>
@@ -135,11 +166,11 @@ function TaxFormulaDialog({ onClose }: { onClose: () => void }) {
             </tbody>
           </table>
         </div>
-        <div className="flex justify-end border-t border-gray-100 px-5 py-3">
+        <div className="flex items-center justify-end gap-2 border-t border-gray-100 px-4 py-3">
           <button
             type="button"
             onClick={onClose}
-            className="rounded-xl border border-gray-300 bg-white px-4 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+            className="rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
           >
             關閉
           </button>
@@ -147,6 +178,8 @@ function TaxFormulaDialog({ onClose }: { onClose: () => void }) {
       </div>
     </div>
   )
+
+  return createPortal(dialog, document.body)
 }
 
 interface SummaryBodyProps {
@@ -188,7 +221,11 @@ function TaxSummaryBody({
       {/* Calculation rows */}
       <CardBody variant="summary" className="space-y-2.5">
         <SummaryRow
-          label="綜合所得總額"
+          label={(
+            <SummarySectionLink sectionId="gross_income" onScroll={onScrollToSection}>
+              綜合所得總額
+            </SummarySectionLink>
+          )}
           value={grossIncome}
           missing={grossMissing}
           pendingCalculation={grossIncomePendingCalculation}
@@ -196,7 +233,11 @@ function TaxSummaryBody({
           onScroll={onScrollToSection}
         />
         <SummaryRow
-          label="免稅額"
+          label={(
+            <SummarySectionLink sectionId="exemptions" onScroll={onScrollToSection}>
+              免稅額
+            </SummarySectionLink>
+          )}
           value={exemptionAmount}
           isDeduction
           missing={exemptMissing}
@@ -206,11 +247,13 @@ function TaxSummaryBody({
         <SummaryRow
           label={(
             <span className="inline-flex items-center gap-2">
-              <span>一般扣除額</span>
+              <SummarySectionLink sectionId="general_deductions" onScroll={onScrollToSection}>
+                一般扣除額
+              </SummarySectionLink>
               {generalDeductionMethod && (
                 <span
                   data-testid="general-deduction-method-label"
-                  className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-sm font-semibold text-green-800"
+                  className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-sm font-semibold text-blue-800"
                 >
                   {generalDeductionMethod === 'itemized' ? '列舉' : '標準'}
                 </span>
@@ -225,7 +268,11 @@ function TaxSummaryBody({
         />
         {hasSpecialDeductions && (
           <SummaryRow
-            label="特別扣除額"
+            label={(
+              <SummarySectionLink sectionId="special_deductions" onScroll={onScrollToSection}>
+                特別扣除額
+              </SummarySectionLink>
+            )}
             value={specialDeductionAmount}
             isDeduction
             missing={specialMissing}
@@ -253,13 +300,16 @@ function TaxSummaryBody({
             {onOpenDialog && (
               <span className="shrink-0 text-sm text-muted">
                 <span aria-hidden>(</span>
-                <button
-                  type="button"
-                  onClick={onOpenDialog}
-                  className="inline p-0 border-0 bg-transparent font-inherit text-sm text-muted hover:text-blue-600 hover:underline underline-offset-2 transition-colors cursor-pointer"
+                <a
+                  href="#tax-formula-detail"
+                  onClick={(event) => {
+                    event.preventDefault()
+                    onOpenDialog()
+                  }}
+                  className="inline p-0 m-0 border-0 bg-transparent font-inherit text-sm text-gray-600 hover:text-gray-800 hover:underline underline-offset-2 transition-colors leading-none align-baseline"
                 >
-                  瞭解更多
-                </button>
+                  了解更多
+                </a>
                 <span aria-hidden>)</span>
               </span>
             )}

--- a/src/components/checklist/ChecklistInlineAmountFields.tsx
+++ b/src/components/checklist/ChecklistInlineAmountFields.tsx
@@ -11,6 +11,26 @@ function formatAmount(value: number) {
   return Math.round(value).toLocaleString('zh-TW')
 }
 
+function getPerUnitInlineFormula(field: CardInlineField, value: string): { perUnit: number; total: number } | null {
+  if (!field.perUnitKey) return null
+
+  const hasValue = value.trim() !== ''
+  if (!hasValue) return null
+
+  const count = Number(value)
+  if (!Number.isFinite(count) || count <= 0) return null
+
+  let perUnit: number
+  try {
+    perUnit = getNumber(field.perUnitKey)
+  } catch {
+    return null
+  }
+
+  const total = count * perUnit
+  return { perUnit, total }
+}
+
 function CapFeedback({
   value,
   cap,
@@ -58,13 +78,17 @@ function InlineFeedback({
   const hasValue = value.trim() !== ''
   const savingsTargetItemId = 'savings-investment-deduction'
   const savingsLink = (
-    <button
-      type="button"
-      onClick={() => feedbackContext?.onScrollToItem?.(savingsTargetItemId)}
-      className="font-medium text-blue-700 hover:text-blue-800 hover:underline underline-offset-2 transition-colors"
+    <a
+      href={`#${savingsTargetItemId}`}
+      onClick={(event) => {
+        if (!feedbackContext?.onScrollToItem) return
+        event.preventDefault()
+        feedbackContext.onScrollToItem(savingsTargetItemId)
+      }}
+      className="inline p-0 m-0 border-0 bg-transparent font-inherit text-gray-600 hover:text-gray-800 hover:underline underline-offset-2 transition-colors leading-none align-baseline"
     >
       儲蓄投資特別扣除額
-    </button>
+    </a>
   )
 
   if (field.splitPerUnitKeys) {
@@ -81,31 +105,12 @@ function InlineFeedback({
     const additionalCount = Math.max(count - 1, 0)
     const total = firstRate + additionalCount * additionalRate
     return (
-      <p className="mt-1 text-base text-blue-700">
+      <p className="mt-1 text-base text-gray-700">
         {count === 1 ? (
           <>1 {field.unit} × {firstRate.toLocaleString('zh-TW')} 元 ＝ <strong>{total.toLocaleString('zh-TW')} 元</strong></>
         ) : (
           <>1 {field.unit} × {firstRate.toLocaleString('zh-TW')} ＋ {additionalCount} {field.unit} × {additionalRate.toLocaleString('zh-TW')} ＝ <strong>{total.toLocaleString('zh-TW')} 元</strong></>
         )}
-      </p>
-    )
-  }
-
-  if (field.perUnitKey) {
-    if (!hasValue) return null
-    const count = Number(value)
-    if (!Number.isFinite(count) || count <= 0) return null
-    let perUnit: number
-    try {
-      perUnit = getNumber(field.perUnitKey)
-    } catch {
-      return null
-    }
-    const total = count * perUnit
-    return (
-      <p className="mt-1 text-base text-blue-700">
-        {count} {field.unit} × {perUnit.toLocaleString('zh-TW')} 元 ＝{' '}
-        <strong>{total.toLocaleString('zh-TW')} 元</strong>
       </p>
     )
   }
@@ -241,13 +246,13 @@ export function ChecklistInlineAmountFields({
   if (inlineFields.length === 0) return null
 
   return (
-    <div className="mt-3 space-y-3 rounded border border-blue-100 bg-blue-50/40 p-3">
+    <div className="mt-3 space-y-3 rounded-xl border border-gray-300 bg-gray-100/70 p-3">
       {inlineFields.map((field) => (
         <div key={field.id}>
           <label className="block text-base font-medium text-gray-600 mb-1">
             {field.label}（選填）
           </label>
-          <div className="flex items-center gap-1.5">
+          <div className="flex flex-wrap items-center gap-1.5">
             <input
               type="number"
               min="0"
@@ -263,6 +268,15 @@ export function ChecklistInlineAmountFields({
               placeholder={field.perUnitKey || field.splitPerUnitKeys ? '輸入人數' : '輸入金額'}
             />
             <span className="text-base text-gray-500">{field.unit}</span>
+            {(() => {
+              const formula = getPerUnitInlineFormula(field, inputValues[field.id] ?? '')
+              if (!formula) return null
+              return (
+                <span className="text-base text-gray-700">
+                  × {formula.perUnit.toLocaleString('zh-TW')} 元 ＝ <strong>{formula.total.toLocaleString('zh-TW')} 元</strong>
+                </span>
+              )
+            })()}
           </div>
           <InlineFeedback
             field={field}
@@ -271,7 +285,7 @@ export function ChecklistInlineAmountFields({
           />
         </div>
       ))}
-      <div className="border-t border-blue-100 pt-2">
+      <div className="border-t border-gray-300 pt-2">
         <p className="text-xs text-gray-400">
           資料僅在您的瀏覽器處理，不會傳送至任何伺服器
         </p>

--- a/src/components/checklist/FormulaRow.tsx
+++ b/src/components/checklist/FormulaRow.tsx
@@ -90,7 +90,7 @@ export function FormulaRow({
       <div className="mt-3 flex items-baseline gap-1.5">
         <span className="text-base font-bold text-gray-400">＝</span>
         {allFilled ? (
-          <span className="text-base font-bold tabular-nums text-green-700">
+          <span className="text-base font-bold tabular-nums text-gray-800">
             {partialTotal.toLocaleString('zh-TW')} 元
           </span>
         ) : anyFilled ? (

--- a/src/components/checklist/StandardItemizedPanel.tsx
+++ b/src/components/checklist/StandardItemizedPanel.tsx
@@ -33,7 +33,7 @@ function Verdict({
   if (allFilled) {
     if (itemizedTotal > standardAmount) {
       return (
-        <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-base font-semibold text-green-800">
+        <span className="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-base font-semibold text-blue-800">
           推薦：列舉扣除（列舉扣除 {'>'} 標準扣除）
         </span>
       )
@@ -46,7 +46,7 @@ function Verdict({
       )
     }
     return (
-      <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-base font-semibold text-green-800">
+      <span className="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-base font-semibold text-blue-800">
         推薦：標準扣除（標準扣除 {'>'} 列舉扣除）
       </span>
     )
@@ -113,7 +113,7 @@ export function StandardItemizedPanel({ groups, selectedSituations, cardInputMap
     return (
       <section className={PANEL_SHELL_CLASS} data-testid="standard-itemized-panel">
         <div className="mb-3">
-          <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-base font-semibold text-green-800">
+          <span className="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-base font-semibold text-blue-800">
             推薦：標準扣除
           </span>
         </div>

--- a/tests/checklist.test.ts
+++ b/tests/checklist.test.ts
@@ -883,6 +883,27 @@ describe('DeductionCard inline input fields', () => {
     feedbackRule: 'mortgage-interest',
   }
 
+  const perUnitCountField: CardInlineField = {
+    id: 'exemption_under70_count',
+    label: '一般免稅額人數（未滿 70 歲）',
+    type: 'number',
+    unit: '人',
+    capKey: null,
+    perUnitKey: 'exemption_general',
+  }
+
+  const splitPerUnitCountField: CardInlineField = {
+    id: 'childcare_count',
+    label: '幼兒人數',
+    type: 'number',
+    unit: '人',
+    capKey: null,
+    splitPerUnitKeys: {
+      firstKey: 'special_deduction_childcare_first',
+      additionalKey: 'special_deduction_childcare_additional',
+    },
+  }
+
   it('renders without input area when inlineFields is empty', () => {
     const html = renderToStaticMarkup(
       createElement(DeductionCard, { item: makeItem(), inlineFields: [] }),
@@ -936,6 +957,41 @@ describe('DeductionCard inline input fields', () => {
       }),
     )
     expect(html).toContain('可申報上限為 218,000 元')
+  })
+
+  it('does not show per-unit formula when count field is empty', () => {
+    const html = renderToStaticMarkup(
+      createElement(DeductionCard, {
+        item: makeItem(),
+        inlineFields: [perUnitCountField],
+        inputValues: { exemption_under70_count: '' },
+      }),
+    )
+    expect(html).not.toContain('× 97,000 元 ＝')
+  })
+
+  it('shows per-unit formula inline when count field has value', () => {
+    const html = renderToStaticMarkup(
+      createElement(DeductionCard, {
+        item: makeItem(),
+        inlineFields: [perUnitCountField],
+        inputValues: { exemption_under70_count: '1' },
+      }),
+    )
+    expect(html).not.toContain('1 人 ×')
+    expect(html).toContain('× 97,000 元 ＝ <strong>97,000 元</strong>')
+  })
+
+  it('keeps split per-unit formula behavior for childcare fields', () => {
+    const html = renderToStaticMarkup(
+      createElement(DeductionCard, {
+        item: makeItem(),
+        inlineFields: [splitPerUnitCountField],
+        inputValues: { childcare_count: '2' },
+      }),
+    )
+    expect(html).toContain('1 人 × 150,000 ＋ 1 人 × 225,000 ＝')
+    expect(html).toContain('375,000 元')
   })
 
   it('shows no feedback when capKey is null', () => {

--- a/tests/situation-single-source-flow.test.tsx
+++ b/tests/situation-single-source-flow.test.tsx
@@ -146,12 +146,12 @@ function renderApp({ autoStart = true }: { autoStart?: boolean } = {}) {
 }
 
 function clickButtonByText(text: string) {
-  const button = Array.from(container.querySelectorAll('button')).find((el) =>
+  const clickable = Array.from(container.querySelectorAll<HTMLElement>('button, a')).find((el) =>
     el.textContent?.includes(text),
   )
-  if (!button) throw new Error(`Missing button with text "${text}"`)
+  if (!clickable) throw new Error(`Missing clickable element with text "${text}"`)
   act(() => {
-    button.click()
+    clickable.click()
   })
 }
 
@@ -305,6 +305,34 @@ describe('situation single-source flow', () => {
     expect(savedSelectionAfterRemove).not.toContain('rent')
     expect(localStorage.getItem(SITUATION_SELECTION_STORAGE_KEY)).toContain('donations')
   })
+
+  it('opens and closes tax formula dialog with shared modal overlay classes', () => {
+    renderApp()
+    clickButtonByText('薪資收入')
+    clickButtonByText('產生節稅清單')
+
+    clickButtonByText('了解更多')
+
+    const overlay = document.querySelector<HTMLElement>('[data-testid="tax-formula-dialog-overlay"]')
+    expect(overlay).not.toBeNull()
+    expect(overlay?.classList.contains('fixed')).toBe(true)
+    expect(overlay?.classList.contains('inset-0')).toBe(true)
+    expect(overlay?.classList.contains('bg-gray-900/40')).toBe(true)
+    expect(overlay?.classList.contains('no-print')).toBe(true)
+
+    const dialog = document.querySelector<HTMLElement>('[data-testid="tax-formula-dialog"]')
+    expect(dialog).not.toBeNull()
+
+    const closeButton = dialog?.querySelector<HTMLButtonElement>('button[aria-label="關閉"]')
+    expect(closeButton).not.toBeNull()
+    act(() => {
+      closeButton?.click()
+    })
+
+    expect(document.querySelector('[data-testid="tax-formula-dialog-overlay"]')).toBeNull()
+    expect(document.querySelector('[data-testid="tax-formula-dialog"]')).toBeNull()
+  })
+
   it('does not show remove button for non-removable cards', () => {
     renderApp()
     clickButtonByText('薪資收入')


### PR DESCRIPTION
## Summary
- Extract shared navigation helpers for intro and header entry points
- Navigate to results when selections exist, otherwise go to selecting
- Keep scroll-to-top and checklist view-state persistence consistent
- Update reset-flow test and add coverage for intro/header and refresh behavior

## Checks

- [x] No personal tax data or private documents included
- [x] Tax-related claims are sourced or marked as draft
- [x] Changes are scoped to this PR
