### PR TITLE
feat(revamp-income-card-and-summary): - add per-card participant mana…

### DIFF
--- a/src/components/ChecklistResult.tsx
+++ b/src/components/ChecklistResult.tsx
@@ -787,6 +787,29 @@ export function ChecklistResult({
             ? 'itemized'
             : 'standard')
 
+  function handleRemovePersonFromCard(cardId: IncomeCardId, personId: string) {
+    // Remove from this card's persons_json
+    const cardPersons = parseIncomeCardPersons(cardInputMap[cardId] ?? {}, incomeParticipants)
+      .filter((p) => p.id !== 'self' && p.id !== personId && (p.id === 'spouse' || p.hasInput))
+      .map((p): GrossIncomePerson => ({ id: p.id, label: p.label, income: p.income }))
+    onCardInputChange(cardId, 'persons_json', serializeIncomeAmounts(cardPersons))
+
+    // If not in any other card, remove from global participants too
+    const stillInOtherCard = INCOME_CARD_IDS
+      .filter((id) => id !== cardId)
+      .some((otherId) =>
+        parseIncomeCardPersons(cardInputMap[otherId] ?? {}, incomeParticipants)
+          .some((p) => p.id === personId && p.hasInput),
+      )
+
+    if (!stillInOtherCard) {
+      handleIncomeParticipantsChange(
+        incomeParticipants.filter((p) => p.id !== 'self' && p.id !== personId),
+        personId,
+      )
+    }
+  }
+
   function handleIncomeParticipantsChange(nextParticipants: IncomeParticipant[], removedId?: string) {
     onCardInputChange(
       INCOME_PARTICIPANTS_ITEM_ID,
@@ -799,7 +822,7 @@ export function ChecklistResult({
       const raw = cardInputMap[itemId]?.['persons_json']
       if (!raw) continue
       const persons = parseIncomeCardPersons(cardInputMap[itemId] ?? {}, incomeParticipants)
-        .filter((p) => p.id !== 'self' && p.id !== removedId)
+        .filter((p) => p.id !== 'self' && p.id !== removedId && p.hasInput)
         .map((p): GrossIncomePerson => ({ id: p.id, label: p.label, income: p.income }))
       onCardInputChange(itemId, 'persons_json', serializeIncomeAmounts(persons))
     }
@@ -1032,6 +1055,7 @@ export function ChecklistResult({
                           removable={!NON_REMOVABLE_ITEM_IDS.has(item.id)}
                           onInputChange={(fieldId, value) => onCardInputChange(item.id, fieldId, value)}
                           onParticipantsChange={handleIncomeParticipantsChange}
+                          onRemovePersonFromCard={(personId) => handleRemovePersonFromCard(item.id as IncomeCardId, personId)}
                           onRemove={() => onRemoveItem?.(item.id)}
                         />
                       ) : item.id === 'savings-investment-deduction' ? (

--- a/src/components/IncomeCard.tsx
+++ b/src/components/IncomeCard.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef, useEffect } from 'react'
 import type { ChecklistItem } from '../types/content'
 import {
   calcPersonDeduction,
@@ -25,6 +26,7 @@ interface Props {
   onInputChange: (fieldId: string, value: string) => void
   onParticipantsChange: (participants: IncomeParticipant[], removedId?: string) => void
   onRemove?: () => void
+  onRemovePersonFromCard?: (personId: string) => void
 }
 
 function formatTwd(n: number) {
@@ -39,10 +41,12 @@ function getInputRaw(
   if (person.id === 'self') {
     const raw = inputValues['self_income']
     if (raw !== undefined) return raw
-    return config.requiresExplicitInput ? '' : '0'
+    return config.requiresExplicitInput ? '' : ''
   }
-  if (!person.hasInput && !config.requiresExplicitInput) return '0'
+  if (!person.hasInput && !config.requiresExplicitInput) return ''
   if (!person.hasInput) return ''
+  // Extra relatives (extra-N) treat income=0 same as empty — both are valid "no income" states
+  if (person.id.startsWith('extra-') && person.income === 0) return ''
   return String(person.income)
 }
 
@@ -53,8 +57,57 @@ interface PersonRowProps {
   isFixed: boolean
   labelPlaceholder?: string
   onIncomeChange: (value: string) => void
-  onLabelChange?: (value: string) => void
+  onEditLabel?: () => void
   onRemove?: () => void
+}
+
+function FormulaCol({ label, amount, amountClass }: { label: string; amount: number; amountClass: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[14px] leading-tight text-gray-500">{label}</span>
+      <span className={`text-[16px] font-semibold tabular-nums leading-tight ${amountClass}`}>
+        {amount.toLocaleString('zh-TW')} 元
+      </span>
+    </div>
+  )
+}
+
+function SalaryFormulaInline({
+  income,
+  deduction,
+  net,
+  showFullDeductionHint,
+}: {
+  income: number
+  deduction: number
+  net: number
+  showFullDeductionHint: boolean
+}) {
+  const netColor = net > 0 ? 'text-gray-800' : 'text-green-700'
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+      <FormulaCol label="薪資收入" amount={income} amountClass="text-gray-700" />
+      <span className="select-none self-end pb-[2px] text-sm text-gray-400">−</span>
+      <div className="flex flex-col gap-0.5">
+        <span className="text-[14px] leading-tight text-gray-500">薪資所得特別扣除額</span>
+        <span className="text-[16px] font-semibold tabular-nums leading-tight text-gray-700">
+          {deduction.toLocaleString('zh-TW')} 元
+          {showFullDeductionHint && <span className="ml-1 text-xs font-normal text-gray-400">（全額扣除）</span>}
+        </span>
+      </div>
+      <span className="select-none self-end pb-[2px] text-sm text-gray-400">＝</span>
+      <FormulaCol label="薪資淨額" amount={net} amountClass={netColor} />
+    </div>
+  )
+}
+
+function PencilIcon() {
+  return (
+    <svg width="28" height="28" viewBox="2 2 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+    </svg>
+  )
 }
 
 function PersonRow({
@@ -64,7 +117,7 @@ function PersonRow({
   isFixed,
   labelPlaceholder,
   onIncomeChange,
-  onLabelChange,
+  onEditLabel,
   onRemove,
 }: PersonRowProps) {
   const cap = getSalaryDeductionCap()
@@ -74,26 +127,26 @@ function PersonRow({
   const hasSalaryFormula = config.kind === 'salary' && person.hasInput && income > 0
 
   return (
-    <div className="border-b border-gray-300 py-3 first:pt-0 last:border-0 last:pb-0">
+    <div className="border-b border-gray-300 py-3 first:pt-0 last:border-0">
       <div className="mb-1.5 flex items-center gap-2">
-        {isFixed ? (
-          <span className="min-w-[3rem] text-base font-semibold text-gray-700">{person.label}</span>
-        ) : (
-          <input
-            type="text"
-            value={person.label}
-            onChange={(e) => onLabelChange?.(e.target.value)}
-            placeholder={labelPlaceholder ?? '稱謂'}
-            data-testid={`income-label-${config.id}-${person.id}`}
-            className="w-28 rounded border border-gray-200 px-1.5 py-0.5 text-base font-semibold text-gray-700 focus:border-blue-400 focus:outline-none"
-          />
+        <span className={`text-base font-semibold ${person.label ? 'text-gray-700' : 'text-gray-400'}`}>
+          {person.label || labelPlaceholder || '稱謂'}
+        </span>
+        {!isFixed && onEditLabel && (
+          <span
+            onClick={onEditLabel}
+            aria-label={`編輯 ${person.label || '此人員'} 的稱謂`}
+            className="inline-flex h-4 w-4 cursor-pointer items-center justify-center text-gray-400 transition-colors hover:text-gray-600"
+          >
+            <PencilIcon />
+          </span>
         )}
         {!isFixed && onRemove && (
           <button
             type="button"
             onClick={onRemove}
             aria-label={`移除 ${person.label || '此人員'}`}
-            className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded-full border border-gray-200 text-xs text-gray-400 transition-colors hover:border-red-300 hover:bg-red-50 hover:text-red-500"
+            className="ml-auto inline-flex h-7 w-7 items-center justify-center text-[24px] text-gray-400 transition-colors hover:text-gray-700"
           >
             ×
           </button>
@@ -108,25 +161,109 @@ function PersonRow({
           min="0"
           value={incomeRaw}
           onChange={(e) => onIncomeChange(e.target.value)}
-          placeholder={config.placeholder}
+          placeholder="輸入金額"
           data-testid={`income-input-${config.id}-${person.id}`}
           className="no-spin w-40 rounded border border-gray-300 px-2 py-1 text-base text-gray-800 focus:border-blue-400 focus:outline-none"
         />
         <span className="text-base text-gray-500">元</span>
       </div>
       {hasSalaryFormula && (
-        <p className="mt-1.5 text-base text-gray-500">
-          {'綜合所得 ＝ 薪資收入 − 薪資所得特別扣除額 ＝ '}
-          <span className="font-medium text-gray-700">{formatTwd(income)} 元</span>
-          {' − '}
-          <span className="font-medium text-indigo-700">{formatTwd(deduction)} 元</span>
-          {income <= cap && <span className="text-gray-400">（全額扣除）</span>}
-          {' ＝ '}
-          <span className={`font-medium ${net > 0 ? 'text-gray-800' : 'text-green-700'}`}>
-            {formatTwd(net)} 元
-          </span>
-        </p>
+        <div className="mt-2">
+          <SalaryFormulaInline
+            income={income}
+            deduction={deduction}
+            net={net}
+            showFullDeductionHint={income <= cap}
+          />
+        </div>
       )}
+    </div>
+  )
+}
+
+interface NameDialogProps {
+  title: string
+  label: string
+  onLabelChange: (v: string) => void
+  onConfirm: () => void
+  onCancel: () => void
+  confirmLabel: string
+}
+
+function NameDialog({ title, label, onLabelChange, onConfirm, onCancel, confirmLabel }: NameDialogProps) {
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onCancel])
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-gray-900/40"
+      onClick={(e) => { if (e.target === e.currentTarget) onCancel() }}
+    >
+      <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl">
+        <h2 className="mb-4 text-base font-semibold text-gray-800">{title}</h2>
+        <input
+          type="text"
+          value={label}
+          onChange={(e) => onLabelChange(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter' && label.trim()) onConfirm() }}
+          placeholder="稱謂"
+          autoFocus
+          className="w-full rounded border border-gray-300 px-3 py-2 text-base text-gray-800 focus:border-blue-400 focus:outline-none"
+        />
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100"
+          >
+            取消
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={label.trim() === ''}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-40"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface AddRelativeMenuProps {
+  extrasNotInThisCard: IncomeParticipant[]
+  onSelectExisting: (personId: string) => void
+  onNewRelative: () => void
+}
+
+function AddRelativeMenu({ extrasNotInThisCard, onSelectExisting, onNewRelative }: AddRelativeMenuProps) {
+  return (
+    <div className="absolute top-full mt-2 left-0 z-20 min-w-[160px] overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg">
+      {extrasNotInThisCard.map((p) => (
+        <button
+          key={p.id}
+          type="button"
+          onClick={() => onSelectExisting(p.id)}
+          className="block w-full px-3 py-2 text-left text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+        >
+          {p.label || p.id}
+        </button>
+      ))}
+      {extrasNotInThisCard.length > 0 && <div className="mx-3 border-t border-gray-200" />}
+      <button
+        type="button"
+        onClick={onNewRelative}
+        className="block w-full px-3 py-2 text-left text-sm font-medium text-blue-600 transition-colors hover:bg-gray-50"
+      >
+        ＋ 新增
+      </button>
     </div>
   )
 }
@@ -141,16 +278,50 @@ export function IncomeCard({
   onInputChange,
   onParticipantsChange,
   onRemove,
+  onRemovePersonFromCard,
 }: Props) {
+  const [dialogMode, setDialogMode] = useState<'add' | 'edit' | null>(null)
+  const [dialogLabel, setDialogLabel] = useState('')
+  const [editingPersonId, setEditingPersonId] = useState<string | null>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const menuContainerRef = useRef<HTMLDivElement>(null)
+
   const persons = parseIncomeCardPersons(inputValues, participants)
-  const amountPersons = persons.map(({ id, label, income }) => ({ id, label, income }))
+  const visiblePersons = persons.filter((p) => p.id === 'self' || p.id === 'spouse' || p.hasInput)
+
+  const amountPersons = visiblePersons.map(({ id, label, income }) => ({ id, label, income }))
   const total = config.kind === 'salary'
-    ? persons.reduce((sum, p) => sum + calcPersonNetIncome(p.income), 0)
+    ? visiblePersons.reduce((sum, p) => sum + calcPersonNetIncome(p.income), 0)
     : calcRawIncomeTotal(amountPersons)
-  const isComplete = incomeCardIsComplete(config, persons)
+  const isComplete = incomeCardIsComplete(config, visiblePersons)
 
   const participantsInJson = participants.filter((p) => p.id !== 'self')
   const extraPersonsOrdered = participantsInJson.filter((p) => p.id.startsWith('extra-'))
+  const globalExtras = participants.filter((p) => p.id.startsWith('extra-'))
+  const extrasInThisCard = new Set(
+    persons.filter((p) => p.id.startsWith('extra-') && p.hasInput).map((p) => p.id),
+  )
+  const extrasNotInThisCard = globalExtras.filter((p) => !extrasInThisCard.has(p.id))
+
+  useEffect(() => {
+    if (!menuOpen) return
+    function handleClickOutside(e: MouseEvent) {
+      if (menuContainerRef.current && !menuContainerRef.current.contains(e.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [menuOpen])
+
+  useEffect(() => {
+    if (!menuOpen) return
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setMenuOpen(false)
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [menuOpen])
 
   function updateAmount(targetId: string, value: string) {
     if (targetId === 'self') {
@@ -159,11 +330,10 @@ export function IncomeCard({
     }
     const next = persons
       .filter((p) => p.id !== 'self')
-      .filter((p) =>
-        config.requiresExplicitInput
-          ? (p.id === targetId ? value.trim() !== '' : p.hasInput)
-          : true,
-      )
+      .filter((p) => {
+        if (p.id === targetId) return !config.requiresExplicitInput || targetId.startsWith('extra-') ? true : value.trim() !== ''
+        return p.id === 'spouse' || p.hasInput
+      })
       .map((p) => (
         p.id === targetId
           ? { id: p.id, label: p.label, income: parseIncome(value) }
@@ -180,22 +350,78 @@ export function IncomeCard({
   }
 
   function handleRemovePerson(targetId: string) {
-    const next = participantsInJson.filter((p) => p.id !== targetId)
-    onParticipantsChange(next, targetId)
+    if (onRemovePersonFromCard) {
+      onRemovePersonFromCard(targetId)
+    } else {
+      const next = participantsInJson.filter((p) => p.id !== targetId)
+      onParticipantsChange(next, targetId)
+    }
   }
 
-  function handleAddPerson() {
+  function openAddDialog() {
+    setDialogLabel(defaultExtraDependentLabel(globalExtras.length))
+    setDialogMode('add')
+    setMenuOpen(false)
+  }
+
+  function openEditDialog(personId: string, currentLabel: string) {
+    setEditingPersonId(personId)
+    setDialogLabel(currentLabel)
+    setDialogMode('edit')
+  }
+
+  function closeDialog() {
+    setDialogMode(null)
+    setEditingPersonId(null)
+    setDialogLabel('')
+  }
+
+  function handleClickAdd() {
+    if (extrasNotInThisCard.length === 0) {
+      openAddDialog()
+    } else {
+      setMenuOpen((v) => !v)
+    }
+  }
+
+  function handleCreateNew() {
+    const label = dialogLabel.trim()
+    if (!label) return
+
     const extraNums = participantsInJson
       .filter((p) => p.id.startsWith('extra-'))
       .map((p) => parseInt(p.id.slice('extra-'.length), 10))
       .filter((n) => Number.isFinite(n))
-    const nextId = extraNums.length > 0 ? Math.max(...extraNums) + 1 : 0
-    const extraCount = participantsInJson.filter((p) => p.id.startsWith('extra-')).length
-    const next = [
-      ...participantsInJson,
-      { id: `extra-${nextId}`, label: defaultExtraDependentLabel(extraCount) },
-    ]
-    onParticipantsChange(next)
+    const nextNum = extraNums.length > 0 ? Math.max(...extraNums) + 1 : 0
+    const nextId = `extra-${nextNum}`
+
+    onParticipantsChange([...participantsInJson, { id: nextId, label }])
+
+    const currentInCard = persons
+      .filter((p) => p.id !== 'self' && (p.id === 'spouse' || p.hasInput))
+      .map((p) => ({ id: p.id, label: p.label, income: p.income }))
+    onInputChange('persons_json', serializeIncomeAmounts([...currentInCard, { id: nextId, label, income: 0 }]))
+
+    closeDialog()
+  }
+
+  function handleSaveLabel() {
+    if (!editingPersonId || !dialogLabel.trim()) return
+    handlePersonLabelChange(editingPersonId, dialogLabel.trim())
+    closeDialog()
+  }
+
+  function handleAddExisting(personId: string) {
+    const currentInCard = persons
+      .filter((p) => p.id !== 'self' && (p.id === 'spouse' || p.hasInput))
+      .map((p) => ({ id: p.id, label: p.label, income: p.income }))
+    const person = participants.find((p) => p.id === personId)
+    if (!person) return
+    onInputChange('persons_json', serializeIncomeAmounts([
+      ...currentInCard,
+      { id: personId, label: person.label, income: 0 },
+    ]))
+    setMenuOpen(false)
   }
 
   return (
@@ -211,56 +437,85 @@ export function IncomeCard({
         </p>
       )}
 
-      <div className="space-y-0 rounded-xl border border-gray-300 bg-gray-100/70 p-3">
-        {persons.map((person) => {
-          const isFixed = person.id === 'self' || person.id === 'spouse'
-          const extraOrder =
-            person.id.startsWith('extra-') ? extraPersonsOrdered.findIndex((p) => p.id === person.id) + 1 : 0
-          const labelPlaceholder =
-            !isFixed && person.id.startsWith('extra-') && !person.label.trim()
-              ? defaultExtraDependentLabel(extraOrder - 1)
-              : undefined
-          return (
-            <PersonRow
-              key={person.id}
-              person={person}
-              config={config}
-              incomeRaw={getInputRaw(person, config, inputValues)}
-              isFixed={isFixed}
-              labelPlaceholder={labelPlaceholder}
-              onIncomeChange={(val) => updateAmount(person.id, val)}
-              onLabelChange={isFixed ? undefined : (val) => handlePersonLabelChange(person.id, val)}
-              onRemove={isFixed ? undefined : () => handleRemovePerson(person.id)}
-            />
-          )
-        })}
-      </div>
+      <div className="rounded-xl border border-gray-300 bg-gray-100/70 p-3">
+        <div className="space-y-0">
+          {visiblePersons.map((person) => {
+            const isFixed = person.id === 'self' || person.id === 'spouse'
+            const extraOrder =
+              person.id.startsWith('extra-') ? extraPersonsOrdered.findIndex((p) => p.id === person.id) + 1 : 0
+            const labelPlaceholder =
+              !isFixed && person.id.startsWith('extra-') && !person.label.trim()
+                ? defaultExtraDependentLabel(extraOrder - 1)
+                : undefined
+            return (
+              <PersonRow
+                key={person.id}
+                person={person}
+                config={config}
+                incomeRaw={getInputRaw(person, config, inputValues)}
+                isFixed={isFixed}
+                labelPlaceholder={labelPlaceholder}
+                onIncomeChange={(val) => updateAmount(person.id, val)}
+                onEditLabel={isFixed ? undefined : () => openEditDialog(person.id, person.label)}
+                onRemove={isFixed ? undefined : () => handleRemovePerson(person.id)}
+              />
+            )
+          })}
+        </div>
 
-      <button
-        type="button"
-        onClick={handleAddPerson}
-        className="no-print mt-2 flex items-center gap-1 text-xs text-blue-600 transition-colors hover:text-blue-800"
-        data-testid={`income-add-person-${config.id}`}
-      >
-        <span aria-hidden="true">＋</span>
-        <span>新增共同報稅者</span>
-      </button>
+        <div className="relative mt-2 border-t border-gray-200 pt-3" ref={menuContainerRef}>
+          <button
+            type="button"
+            onClick={handleClickAdd}
+            data-testid={`income-add-person-${config.id}`}
+            className="no-print inline-flex items-center gap-1 rounded-xl border border-gray-300 bg-white px-2.5 py-1 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+          >
+            ＋ 新增共同報稅者
+          </button>
+          {menuOpen && (
+            <AddRelativeMenu
+              extrasNotInThisCard={extrasNotInThisCard}
+              onSelectExisting={handleAddExisting}
+              onNewRelative={openAddDialog}
+            />
+          )}
+        </div>
+      </div>
 
       <p className="mt-2 text-xs text-gray-400">
         資料僅在您的瀏覽器處理，不會傳送至任何伺服器
       </p>
 
-      <div className="mt-3 space-y-0.5 text-base text-gray-500">
-        <p className="font-medium text-gray-700">{config.subtotalLabel}</p>
+      <div className="mt-3">
         {isComplete ? (
-          <div className="flex justify-between gap-4 border-t border-gray-100 pt-0.5 font-semibold text-blue-700" data-testid={`income-total-${config.id}`}>
-            <span>＝</span>
-            <span className="tabular-nums">{formatTwd(total)} 元</span>
-          </div>
+          <p className="text-base font-medium text-gray-700 tabular-nums" data-testid={`income-total-${config.id}`}>
+            小計 {formatTwd(total)} 元
+          </p>
         ) : (
-          <p className="font-semibold text-gray-300" data-testid={`income-total-${config.id}`}>未填寫</p>
+          <p className="text-base font-medium text-gray-300" data-testid={`income-total-${config.id}`}>小計 未填寫</p>
         )}
       </div>
+
+      {dialogMode === 'add' && (
+        <NameDialog
+          title="新增共同報稅者"
+          label={dialogLabel}
+          onLabelChange={setDialogLabel}
+          onConfirm={handleCreateNew}
+          onCancel={closeDialog}
+          confirmLabel="新增"
+        />
+      )}
+      {dialogMode === 'edit' && (
+        <NameDialog
+          title="編輯稱謂"
+          label={dialogLabel}
+          onLabelChange={setDialogLabel}
+          onConfirm={handleSaveLabel}
+          onCancel={closeDialog}
+          confirmLabel="儲存"
+        />
+      )}
     </ChecklistCardShell>
   )
 }

--- a/src/components/checklist/StandardItemizedPanel.tsx
+++ b/src/components/checklist/StandardItemizedPanel.tsx
@@ -102,7 +102,7 @@ export function StandardItemizedPanel({ groups, selectedSituations, cardInputMap
   const isMarried = selectedSituations.includes('married')
   const standardKey = isMarried ? 'standard_deduction_married' : 'standard_deduction_single'
   const standardAmount = getNumber(standardKey)
-  const standardTitle = isMarried ? '標準扣除額（配偶合併申報）' : '標準扣除額（單身）'
+  const standardLabel = isMarried ? '(配偶合併申報)' : '(單身)'
 
   const presentItems = groups
     .flatMap((g) => g.items)
@@ -160,9 +160,6 @@ export function StandardItemizedPanel({ groups, selectedSituations, cardInputMap
 
       <div className="space-y-4">
         <div>
-          <p className={`mb-2 text-base font-semibold ${recommendedSide === 'standard' ? 'text-blue-700' : 'text-gray-400'}`}>
-            標準扣除額
-          </p>
           <div
             data-testid="standard-deduction-container"
             className={`rounded-xl border px-4 py-3 ${
@@ -171,44 +168,13 @@ export function StandardItemizedPanel({ groups, selectedSituations, cardInputMap
                 : 'border-gray-200'
             }`}
           >
-            <div
-              data-testid="standard-deduction-card"
-              className={`checklist-formula-card mx-auto inline-block w-fit ${
-                recommendedSide === 'standard'
-                  ? 'border-blue-200 bg-white'
-                  : 'border-gray-300 bg-gray-50'
-              }`}
-            >
-              <div
-                className={`border-b px-2 py-1.5 text-center ${
-                  recommendedSide === 'standard'
-                    ? 'border-blue-100 bg-blue-50/60'
-                    : 'border-gray-200 bg-gray-100'
-                }`}
-              >
-                <span
-                  className={`checklist-formula-label text-base font-semibold leading-tight ${
-                    recommendedSide === 'standard' ? 'text-blue-700' : 'text-gray-600'
-                  }`}
-                >
-                  {standardTitle}
-                </span>
-              </div>
-              <div className="flex min-h-[44px] items-center justify-center px-2 py-2 text-center">
-                <span className="text-base font-bold tabular-nums leading-tight text-gray-800">
-                  {standardAmount.toLocaleString('zh-TW')}
-                  <br />
-                  <span className="text-xs font-normal text-gray-500">元</span>
-                </span>
-              </div>
-            </div>
+            <p className={`mb-0 text-base font-semibold ${recommendedSide === 'standard' ? 'text-blue-700' : 'text-gray-400'}`}>
+              標準扣除額：{standardAmount.toLocaleString('zh-TW')} 元 {standardLabel}
+            </p>
           </div>
         </div>
 
         <div>
-          <p className={`mb-2 text-base font-semibold ${recommendedSide === 'itemized' ? 'text-blue-700' : 'text-gray-400'}`}>
-            列舉扣除額
-          </p>
           <div
             data-testid="itemized-deduction-card"
             className={`rounded-xl border px-4 py-3 ${
@@ -217,6 +183,9 @@ export function StandardItemizedPanel({ groups, selectedSituations, cardInputMap
                 : 'border-gray-200'
             }`}
           >
+            <p className={`mb-2 text-base font-semibold ${recommendedSide === 'itemized' ? 'text-blue-700' : 'text-gray-400'}`}>
+              列舉扣除額
+            </p>
             <FormulaRow items={formulaItems} dimFilled={recommendedSide === 'standard'} />
           </div>
         </div>

--- a/src/content/deductions.ts
+++ b/src/content/deductions.ts
@@ -47,7 +47,6 @@ export const CHECKLIST_ITEMS: ChecklistItem[] = [
     eligibility_cues: [
       '有薪資收入的納稅義務人、配偶及申報受扶養親屬均需申報',
       `薪資所得特別扣除額每人最高 ${n('special_deduction_salary')} 元，不超過實際薪資收入`,
-      '申報系統通常自動帶入薪資資料，請確認金額正確',
       '本網站簡化扣除額流程，統一採用「薪資所得特別扣除額」計算，無「必要費用」選項。',
     ],
     documents_to_prepare: [],

--- a/src/lib/grossIncome.ts
+++ b/src/lib/grossIncome.ts
@@ -28,7 +28,6 @@ export interface IncomeCardConfig {
   id: IncomeCardId
   kind: IncomeKind
   inputLabel: string
-  subtotalLabel: string
   formulaLabel: string
   placeholder: string
   requiresExplicitInput: boolean
@@ -41,7 +40,6 @@ export const INCOME_CARD_CONFIGS: Record<IncomeCardId, IncomeCardConfig> = {
     id: 'gross-income',
     kind: 'salary',
     inputLabel: '薪資收入',
-    subtotalLabel: '薪資淨額小計',
     formulaLabel: '薪資淨額',
     placeholder: '輸入金額',
     requiresExplicitInput: true,
@@ -50,7 +48,6 @@ export const INCOME_CARD_CONFIGS: Record<IncomeCardId, IncomeCardConfig> = {
     id: 'dividend-income',
     kind: 'dividend',
     inputLabel: '股利收入',
-    subtotalLabel: '股利收入小計',
     formulaLabel: '股利收入',
     placeholder: '預設 0',
     requiresExplicitInput: false,
@@ -59,7 +56,6 @@ export const INCOME_CARD_CONFIGS: Record<IncomeCardId, IncomeCardConfig> = {
     id: 'interest-income',
     kind: 'interest',
     inputLabel: '利息收入',
-    subtotalLabel: '利息收入小計',
     formulaLabel: '利息收入',
     placeholder: '預設 0',
     requiresExplicitInput: false,
@@ -68,7 +64,6 @@ export const INCOME_CARD_CONFIGS: Record<IncomeCardId, IncomeCardConfig> = {
     id: 'other-income',
     kind: 'other',
     inputLabel: '其他收入',
-    subtotalLabel: '其他收入小計',
     formulaLabel: '其他收入',
     placeholder: '預設 0',
     requiresExplicitInput: false,

--- a/tests/checklist.test.ts
+++ b/tests/checklist.test.ts
@@ -507,9 +507,8 @@ describe('ChecklistResult standard vs itemized filing reminder panel', () => {
       }),
     )
     expect(html).toContain('data-testid="standard-deduction-container" class="rounded-xl border px-4 py-3 border-blue-400 bg-blue-50/30 shadow-sm"')
-    expect(html).toContain('data-testid="standard-deduction-card" class="checklist-formula-card mx-auto inline-block w-fit border-blue-200 bg-white"')
     expect(html).toContain('data-testid="itemized-deduction-card" class="rounded-xl border px-4 py-3 border-gray-200"')
-    expect(html).toContain('<p class="mb-2 text-base font-semibold text-blue-700">標準扣除額</p>')
+    expect(html).toContain('<p class="mb-0 text-base font-semibold text-blue-700">標準扣除額：131,000 元 (單身)</p>')
     expect(html).toContain('<p class="mb-2 text-base font-semibold text-gray-400">列舉扣除額</p>')
     expect(html).toContain('checklist-formula-card border-gray-300 bg-gray-50')
   })
@@ -528,8 +527,7 @@ describe('ChecklistResult standard vs itemized filing reminder panel', () => {
     )
     expect(html).toContain('data-testid="itemized-deduction-card" class="rounded-xl border px-4 py-3 border-blue-400 bg-blue-50/30 shadow-sm"')
     expect(html).toContain('data-testid="standard-deduction-container" class="rounded-xl border px-4 py-3 border-gray-200"')
-    expect(html).toContain('data-testid="standard-deduction-card" class="checklist-formula-card mx-auto inline-block w-fit border-gray-300 bg-gray-50"')
-    expect(html).toContain('<p class="mb-2 text-base font-semibold text-gray-400">標準扣除額</p>')
+    expect(html).toContain('<p class="mb-0 text-base font-semibold text-gray-400">標準扣除額：131,000 元 (單身)</p>')
     expect(html).toContain('<p class="mb-2 text-base font-semibold text-blue-700">列舉扣除額</p>')
   })
 
@@ -546,7 +544,6 @@ describe('ChecklistResult standard vs itemized filing reminder panel', () => {
       }),
     )
     expect(html).toContain('data-testid="standard-deduction-container" class="rounded-xl border px-4 py-3 border-blue-400 bg-blue-50/30 shadow-sm"')
-    expect(html).toContain('data-testid="standard-deduction-card" class="checklist-formula-card mx-auto inline-block w-fit border-blue-200 bg-white"')
     expect(html).toContain('data-testid="itemized-deduction-card" class="rounded-xl border px-4 py-3 border-gray-200"')
   })
 })


### PR DESCRIPTION
## Summary
- preserve global participants only when still referenced by other income cards
- show only active participants in each card and refine zero/empty input handling
- redesign salary inline formula and subtotal presentation for clearer income breakdown
- simplify standard deduction display and update related tests/content/config cleanup

- 新增以卡片為單位的共同報稅者管理（可加入既有人員/新增人員、編輯稱謂、卡片內移除）
- 僅在其他所得卡仍有引用時保留全域共同報稅者，避免誤刪仍在使用的人員
- 每張卡片只顯示目前啟用的人員，並優化 0 值與空值的輸入判斷邏輯
- 重設薪資內嵌公式與小計呈現方式，讓所得拆解更直觀易讀
- 簡化標準扣除額顯示，並同步整理相關測試、內容與設定

## Checks

- [ ] No personal tax data or private documents included
- [ ] Tax-related claims are sourced or marked as draft
- [ ] Changes are scoped to this PR
