### PR TITLE
feat(ui): shared modal overlay with Escape and backdrop dismiss

### DIFF
--- a/ai-context/10-ui-components.md
+++ b/ai-context/10-ui-components.md
@@ -2,6 +2,23 @@
 
 All under [`src/components/`](../src/components/) unless noted. User-visible strings are **zh-TW** in source.
 
+## `ModalOverlay.tsx` / `useModalDismiss.ts` (`src/components/ui/`)
+
+Shared modal backdrop wrapper for in-app dialogs.
+
+```ts
+interface ModalOverlayProps extends HTMLAttributes<HTMLDivElement> {
+  onDismiss: () => void
+  dismissEnabled?: boolean
+  children: ReactNode
+}
+```
+
+- **Dismiss**: × / footer buttons (per dialog), **Escape** (`useModalDismiss`), and **click on the dimmed overlay** (`e.target === e.currentTarget`).
+- **Nested modals**: module-level layer stack — only the topmost layer handles Escape (e.g. `TaxFormulaDialog` over `TaxScenarioCombinationsDialog`).
+- **Confirm dialogs** (`RemoveImpactDialog`, `ResetConfirmDialog`): Escape / backdrop call **`onCancel`**, not confirm.
+- Used by `IncomeCard` `NameDialog`, `TaxSummaryPanel` portals, and `ChecklistResult` modals.
+
 ## `SiteHeader.tsx`
 
 ```ts
@@ -65,7 +82,7 @@ interface Props {
 
 - Root uses `print-container` for print layout.
 - Layout: `max-w-5xl` with `lg:grid lg:grid-cols-[1fr_360px]` — main checklist column left, `TaxSummaryPanel` sticky sidebar right (desktop only; `no-print`).
-- Embeds per-category cards, add-situation modal, remove confirmation dialog, export block (markdown copy/download, `window.print()`).
+- Embeds per-category cards, add-situation modal, remove confirmation dialog, export block (markdown copy/download, `window.print()`). Modals use [`ModalOverlay`](../src/components/ui/ModalOverlay.tsx) (Escape + backdrop dismiss).
 - Add-situation modal lists situations not currently present in `selected`; savings-investment is disabled and linked to interest income.
 - Card routing: regular income card ids (`gross-income`, `dividend-income`, `interest-income`, `other-income`) → `IncomeCard`; `savings-investment-deduction` → derived read-only card; all others → `DeductionCard`.
 - Non-removable cards at UI layer: `exemption-general`, `standard-deduction-single`, `standard-deduction-married`, `savings-investment-deduction` (no `×` button).
@@ -155,7 +172,7 @@ interface Props {
 - Rows: 綜合所得總額、（選）海外所得連結至 `#overseas_income`、免稅額、一般扣除額、（選）特別扣除額；所得淨額與應納稅額試算。
 - `exemptionAmount === null` means the required filer/spouse age band is missing, so the row shows「前往填寫」and tax scenarios stay pending.
 - When `taxScenarioResult` is present, shows the best filing/dividend combination, payable tax, and **「推薦：…」only when `taxScenarioResult.scenarios.length > 1`** (single-scenario cases omit the recommendation prefix). Sidebar AMT helper copy appears only when overseas income is positive (domain: `taxScenarioResult.hasOverseasIncome` from [`taxScenarios.ts`](../src/lib/taxScenarios.ts)).
-- **Dialogs** (internal; `createPortal` to `document.body`):
+- **Dialogs** (internal; `createPortal` to `document.body`; overlay via [`ModalOverlay`](../src/components/ui/ModalOverlay.tsx) — Escape and backdrop dismiss, nested Escape closes top layer only):
   - **`TaxFormulaDialog`** (`data-testid="tax-formula-dialog"`): title **「稅率級距」** — static copy for 所得淨額 / 應納稅額 definitions plus the progressive **bracket table** from `getBrackets()`. Does **not** list per-scenario formulas.
   - **`ScenarioRulesDialog`** (`scenario-rules-dialog`): title **試算規則**. Top-level sections: **配偶申報組合** (intro copy plus nested **五種計稅方式** as a numbered list and **扣除額分配**); **股利所得** (merged vs **28%** separate-tax option in prose); **海外所得 AMT** (threshold-oriented prose: overseas aggregate **100** 萬元以上 feeds「基本所得額」; basic amount over **750** 萬元 may trigger AMT); **排序與推薦**. Footer line **配偶計稅方式說明整理自** + anchor text **財政部稅務入口網** linking the eTax `tax-saving-manual` path on `etax.nat.gov.tw`. No embedded scenario formula tables.
   - **`TaxScenarioCombinationsDialog`** (`tax-scenario-combinations-dialog`): title **所有稅額組合** — intro explains scenario count and links to **試算規則** / **稅率級距**; no AMT prose in the header. Sortable table; row `data-testid` **`scenario-row-{scenario.id}`**; expandable rows render **`ScenarioFormulaSections`** from `scenario.formulaSections` (operands, cap/floor tags, take-min cards; AMT in **AMT 計算** when applicable). **配偶計稅方式** column only when any non-single scenario exists. Best row highlighted. Scenario **假設** footer when `scenario.assumptions.length > 0`.

--- a/src/components/ChecklistResult.tsx
+++ b/src/components/ChecklistResult.tsx
@@ -41,6 +41,7 @@ import { IncomeCard } from './IncomeCard'
 import { TaxSummaryPanel } from './TaxSummaryPanel'
 import { PageHeading } from './ui/PageHeading'
 import { Card, CardBody } from './ui/Card'
+import { ModalOverlay } from './ui/ModalOverlay'
 import { ChecklistCardShell } from './checklist/ChecklistCardShell'
 
 export interface RemovalImpactPreview {
@@ -177,7 +178,11 @@ function AddSituationModal({
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-gray-900/40 p-4 no-print">
+    <ModalOverlay
+      onDismiss={onCancel}
+      dismissEnabled={isOpen}
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-gray-900/40 p-4 no-print"
+    >
       <div className="w-full max-w-3xl flex flex-col max-h-[calc(100dvh-2rem)] rounded-xl border border-gray-200 bg-white shadow-xl">
         <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
           <h2 className="text-base font-semibold text-gray-900">新增項目</h2>
@@ -284,7 +289,7 @@ function AddSituationModal({
           </button>
         </div>
       </div>
-    </div>
+    </ModalOverlay>
   )
 }
 
@@ -303,7 +308,10 @@ function RemoveImpactDialog({
   }, [])
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-gray-900/40 p-4 no-print">
+    <ModalOverlay
+      onDismiss={onCancel}
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-gray-900/40 p-4 no-print"
+    >
       <div className="w-full max-w-lg flex flex-col max-h-[calc(100dvh-2rem)] rounded-xl border border-gray-200 bg-white shadow-xl">
         <div className="border-b border-gray-100 px-4 py-3">
           <h2 className="text-base font-semibold text-gray-900">
@@ -339,7 +347,7 @@ function RemoveImpactDialog({
           </button>
         </div>
       </div>
-    </div>
+    </ModalOverlay>
   )
 }
 
@@ -356,7 +364,10 @@ function ResetConfirmDialog({
   }, [])
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-gray-900/40 p-4 no-print">
+    <ModalOverlay
+      onDismiss={onCancel}
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-gray-900/40 p-4 no-print"
+    >
       <div className="w-full max-w-lg flex flex-col max-h-[calc(100dvh-2rem)] rounded-xl border border-gray-200 bg-white shadow-xl">
         <div className="border-b border-gray-100 px-4 py-3">
           <h2 className="text-base font-semibold text-gray-900">重新試算？</h2>
@@ -382,7 +393,7 @@ function ResetConfirmDialog({
           </button>
         </div>
       </div>
-    </div>
+    </ModalOverlay>
   )
 }
 

--- a/src/components/IncomeCard.tsx
+++ b/src/components/IncomeCard.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
+import { ModalOverlay } from './ui/ModalOverlay'
 import type { ChecklistItem } from '../types/content'
 import {
   calcPersonDeduction,
@@ -193,18 +194,10 @@ interface NameDialogProps {
 }
 
 function NameDialog({ title, label, onLabelChange, onConfirm, onCancel, confirmLabel }: NameDialogProps) {
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') onCancel()
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [onCancel])
-
   return (
-    <div
+    <ModalOverlay
+      onDismiss={onCancel}
       className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-gray-900/40"
-      onClick={(e) => { if (e.target === e.currentTarget) onCancel() }}
     >
       <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl">
         <h2 className="mb-4 text-base font-semibold text-gray-800">{title}</h2>
@@ -235,7 +228,7 @@ function NameDialog({ title, label, onLabelChange, onConfirm, onCancel, confirmL
           </button>
         </div>
       </div>
-    </div>
+    </ModalOverlay>
   )
 }
 

--- a/src/components/TaxSummaryPanel.tsx
+++ b/src/components/TaxSummaryPanel.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom'
 import { calcTax, getBrackets } from '../lib/numbers'
 import type { TakeMinCandidate, TaxScenario, TaxScenarioResult } from '../lib/taxScenarios'
 import { Card, CardBody, CardHeader } from './ui/Card'
+import { ModalOverlay } from './ui/ModalOverlay'
 
 interface Props {
   grossIncome: number | null
@@ -123,7 +124,8 @@ function SummaryRow({
 function TaxFormulaDialog({ onClose }: { onClose: () => void }) {
 
   const dialog = (
-    <div
+    <ModalOverlay
+      onDismiss={onClose}
       data-testid="tax-formula-dialog-overlay"
       className="fixed inset-0 z-[70] flex items-center justify-center bg-gray-900/40 p-4 no-print"
     >
@@ -198,7 +200,7 @@ function TaxFormulaDialog({ onClose }: { onClose: () => void }) {
           </button>
         </div>
       </div>
-    </div>
+    </ModalOverlay>
   )
 
   return createPortal(dialog, document.body)
@@ -206,7 +208,8 @@ function TaxFormulaDialog({ onClose }: { onClose: () => void }) {
 
 function ScenarioRulesDialog({ onClose }: { onClose: () => void }) {
   const dialog = (
-    <div
+    <ModalOverlay
+      onDismiss={onClose}
       data-testid="scenario-rules-dialog-overlay"
       className="fixed inset-0 z-[70] flex items-center justify-center bg-gray-900/40 p-4 no-print"
     >
@@ -293,7 +296,7 @@ function ScenarioRulesDialog({ onClose }: { onClose: () => void }) {
           </button>
         </div>
       </div>
-    </div>
+    </ModalOverlay>
   )
 
   return createPortal(dialog, document.body)
@@ -605,7 +608,8 @@ function TaxScenarioCombinationsDialog({
   const colCount = 3 + (hasSpouseScenarios ? 1 : 0) + (scenarioResult.hasDividend ? 1 : 0)
 
   const dialog = (
-    <div
+    <ModalOverlay
+      onDismiss={onClose}
       data-testid="tax-scenario-combinations-dialog-overlay"
       className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center bg-gray-900/40 p-0 sm:p-4 no-print"
     >
@@ -767,7 +771,7 @@ function TaxScenarioCombinationsDialog({
         </div>
 
       </div>
-    </div>
+    </ModalOverlay>
   )
 
   return createPortal(dialog, document.body)

--- a/src/components/ui/ModalOverlay.tsx
+++ b/src/components/ui/ModalOverlay.tsx
@@ -1,0 +1,30 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+import { useModalDismiss } from './useModalDismiss'
+
+export interface ModalOverlayProps extends HTMLAttributes<HTMLDivElement> {
+  onDismiss: () => void
+  dismissEnabled?: boolean
+  children: ReactNode
+}
+
+export function ModalOverlay({
+  onDismiss,
+  dismissEnabled = true,
+  children,
+  onClick,
+  ...props
+}: ModalOverlayProps) {
+  useModalDismiss(onDismiss, dismissEnabled)
+
+  return (
+    <div
+      {...props}
+      onClick={(e) => {
+        onClick?.(e)
+        if (e.target === e.currentTarget) onDismiss()
+      }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/components/ui/useModalDismiss.ts
+++ b/src/components/ui/useModalDismiss.ts
@@ -1,0 +1,39 @@
+import { useEffect, useId } from 'react'
+
+const layerStack: string[] = []
+
+function registerLayer(id: string) {
+  layerStack.push(id)
+}
+
+function unregisterLayer(id: string) {
+  const index = layerStack.lastIndexOf(id)
+  if (index >= 0) layerStack.splice(index, 1)
+}
+
+function isTopLayer(id: string) {
+  return layerStack.at(-1) === id
+}
+
+/** Register Escape-to-dismiss; only the topmost modal layer handles the key. */
+export function useModalDismiss(onDismiss: () => void, enabled = true): void {
+  const layerId = useId()
+
+  useEffect(() => {
+    if (!enabled) return
+    registerLayer(layerId)
+    return () => unregisterLayer(layerId)
+  }, [enabled, layerId])
+
+  useEffect(() => {
+    if (!enabled) return
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Escape' || !isTopLayer(layerId)) return
+      onDismiss()
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [enabled, layerId, onDismiss])
+}

--- a/tests/situation-single-source-flow.test.tsx
+++ b/tests/situation-single-source-flow.test.tsx
@@ -295,6 +295,22 @@ function clickLatestScenarioDialogLinkByText(text: string) {
   })
 }
 
+function pressEscape() {
+  act(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+  })
+}
+
+function openTaxFormulaDialogFromScenario() {
+  renderApp()
+  clickButtonByText('薪資收入')
+  clickButtonByText('產生節稅清單')
+  changeInputByTestId('income-input-gross-income-self', '300000')
+  clickByTestId('card-choice-exemption-general-self_age_band-under_70')
+  clickButtonByText('查看所有稅額組合')
+  clickLatestScenarioDialogLinkByText('稅率級距')
+}
+
 describe('situation single-source flow', () => {
   it('goes to selecting from intro start button when a selection exists but checklist is not generated', () => {
     renderApp({ autoStart: false })
@@ -508,6 +524,41 @@ describe('situation single-source flow', () => {
     expect(document.body.style.overflow).toBe('')
   })
 
+  it('closes tax formula dialog with Escape key', () => {
+    openTaxFormulaDialogFromScenario()
+    expect(document.querySelector('[data-testid="tax-formula-dialog-overlay"]')).not.toBeNull()
+
+    pressEscape()
+
+    expect(document.querySelector('[data-testid="tax-formula-dialog-overlay"]')).toBeNull()
+    expect(getLatestScenarioDialog()).not.toBeNull()
+  })
+
+  it('closes tax formula dialog when clicking the overlay backdrop', () => {
+    openTaxFormulaDialogFromScenario()
+    const overlay = document.querySelector<HTMLElement>('[data-testid="tax-formula-dialog-overlay"]')
+    expect(overlay).not.toBeNull()
+
+    act(() => {
+      overlay?.click()
+    })
+
+    expect(document.querySelector('[data-testid="tax-formula-dialog-overlay"]')).toBeNull()
+    expect(getLatestScenarioDialog()).not.toBeNull()
+  })
+
+  it('closes only the topmost dialog when Escape is pressed in a nested stack', () => {
+    openTaxFormulaDialogFromScenario()
+    expect(document.querySelector('[data-testid="tax-formula-dialog-overlay"]')).not.toBeNull()
+    expect(document.querySelector('[data-testid="tax-scenario-combinations-dialog-overlay"]')).not.toBeNull()
+
+    pressEscape()
+
+    expect(document.querySelector('[data-testid="tax-formula-dialog-overlay"]')).toBeNull()
+    expect(document.querySelector('[data-testid="tax-scenario-combinations-dialog-overlay"]')).not.toBeNull()
+    expect(getLatestScenarioDialog()).not.toBeNull()
+  })
+
   it('does not show remove button for non-removable cards', () => {
     renderApp()
     clickButtonByText('薪資收入')
@@ -631,6 +682,22 @@ describe('situation single-source flow', () => {
     clickByTestId('open-add-situation-modal-btn')
     expect(container.querySelector('[data-testid="add-situation-checkbox-salary_income"]')).not.toBeNull()
     clickByTestId('cancel-add-situations-btn')
+  })
+
+  it('dismisses remove confirmation with Escape without removing the card', () => {
+    renderApp()
+    clickButtonByText('房屋租金支出')
+    clickButtonByText('產生節稅清單')
+    changeInputByTestId('card-input-rent-deduction-rent_amount', '120000')
+
+    clickByTestId('remove-item-rent-deduction')
+    expect(container.textContent).toContain('移除 房屋租金支出')
+
+    pressEscape()
+
+    expect(container.textContent).not.toContain('移除 房屋租金支出')
+    expect(container.querySelector('[data-testid="checklist-item-rent-deduction"]')).not.toBeNull()
+    expect(localStorage.getItem(SITUATION_SELECTION_STORAGE_KEY)).toContain('rent')
   })
 
   it('shows confirmation when removing a card with existing input', () => {


### PR DESCRIPTION
## Summary

Add ModalOverlay and useModalDismiss with a module-level layer stack so only the topmost modal handles Escape.

Wire ChecklistResult, IncomeCard, and TaxSummaryPanel dialogs; confirm dialogs dismiss via onCancel. Document in ai-context and add flow tests for Escape, backdrop, nested stacks, and remove confirmation.

## Checks

- [x] No personal tax data or private documents included
- [x] Tax-related claims are sourced or marked as draft
- [x] Changes are scoped to this PR
