### PR TITLE
style(replace-tax-result-placeholder-with-illustrated-empty-state)

### DIFF
--- a/src/components/TaxSummaryPanel.tsx
+++ b/src/components/TaxSummaryPanel.tsx
@@ -606,7 +606,7 @@ function TaxScenarioCombinationsDialog({
   const bestId = scenarioResult.bestScenario.id
   const hasMultipleScenarios = scenarioResult.scenarios.length > 1
   const hasSpouseScenarios = scenarioResult.scenarios.some((scenario) => scenario.coupleMode !== 'single')
-  // 申報組合 + 配偶計稅方式 (couple only) + 股利申報方式 (conditional) + 最終稅額 + chevron
+  // 申報組合 + 配偶計稅方式 (couple only) + 股利申報方式 (conditional) + 應繳納稅額 + chevron
   const colCount = 3 + (hasSpouseScenarios ? 1 : 0) + (scenarioResult.hasDividend ? 1 : 0)
 
   const dialog = (
@@ -696,7 +696,7 @@ function TaxScenarioCombinationsDialog({
                     onClick={() => handleSort('finalTax')}
                     className="group sticky top-0 z-20 border-b border-gray-200 bg-gray-50 px-4 py-2.5 text-right font-medium cursor-pointer select-none first:rounded-tl-xl last:rounded-tr-xl focus:outline-none hover:text-gray-700 hover:bg-gray-100 transition-colors"
                   >
-                    最終稅額<SortIndicator col="finalTax" sortCol={sortCol} sortDir={sortDir} />
+                    應繳納稅額<SortIndicator col="finalTax" sortCol={sortCol} sortDir={sortDir} />
                   </th>
                     <th className="sticky top-0 z-20 w-9 border-b border-gray-200 bg-gray-50 px-2 py-2.5 first:rounded-tl-xl last:rounded-tr-xl" />
                   </tr>
@@ -806,6 +806,29 @@ interface TaxResultBodyProps {
   onOpenScenarioDialog?: () => void
 }
 
+function IncompleteTaxHint() {
+  return (
+    <div
+      data-testid="tax-result-incomplete-hint"
+      className="py-2 flex flex-col items-center justify-center gap-2 px-3 text-center"
+    >
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        className="shrink-0 text-gray-300"
+        fill="currentColor"
+      >
+        <path d="M12 2.75l2.855 5.786 6.386.929-4.62 4.504 1.091 6.36L12 17.326l-5.712 3.003 1.091-6.36-4.62-4.504 6.386-.929L12 2.75z" />
+      </svg>
+      <p className="text-base leading-relaxed text-muted">
+        填寫完畢後，將推薦稅額組合
+      </p>
+    </div>
+  )
+}
+
 function TaxSummaryBody({
   grossIncome,
   exemptionAmount,
@@ -901,13 +924,7 @@ function TaxSummaryBody({
 function TaxResultBody({ taxAmount, taxScenarioResult, onOpenScenarioDialog }: TaxResultBodyProps) {
   return (
     <CardBody variant="summary">
-      <div
-        className={`rounded-xl border px-3 py-2.5 transition-all ${
-          taxAmount !== null
-            ? 'border-blue-200 bg-blue-50'
-            : 'border-dashed border-gray-200 bg-gray-50'
-        }`}
-      >
+      <div className="pb-2.5 pt-0.5 transition-all">
         {taxScenarioResult && onOpenScenarioDialog && (
           <div className="mb-1.5 text-base text-blue-800">
             {taxScenarioResult.scenarios.length > 1 && (
@@ -916,22 +933,22 @@ function TaxResultBody({ taxAmount, taxScenarioResult, onOpenScenarioDialog }: T
             <span className="font-semibold">{displayScenarioTitle(taxScenarioResult.bestScenario.title)}</span>
           </div>
         )}
-        <div className="flex items-center justify-between gap-2">
-          <span className={`text-base font-semibold ${taxAmount !== null ? 'text-blue-800' : 'text-muted'}`}>
-            {taxScenarioResult ? '應繳納稅額' : '應納稅額'}
-          </span>
-          {taxAmount !== null ? (
+        {taxAmount !== null ? (
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-base font-semibold text-blue-800">
+              {taxScenarioResult ? '應繳納稅額' : '應納稅額'}
+            </span>
             <span className="text-base font-bold tabular-nums text-blue-700">{fmt(taxAmount)} 元</span>
-          ) : (
-            <span className="text-base text-muted">待計算</span>
-          )}
-        </div>
+          </div>
+        ) : (
+          <IncompleteTaxHint />
+        )}
         {taxScenarioResult && onOpenScenarioDialog && (
-          <div className="mt-1.5">
+          <div className="mt-2.5">
             <button
               type="button"
               onClick={onOpenScenarioDialog}
-              className="inline-flex w-full items-center justify-center rounded-lg border border-blue-200 bg-white px-2.5 py-1 text-sm font-medium text-blue-700 hover:bg-blue-100"
+              className="inline-flex w-full items-center justify-center rounded-xl border border-gray-300 bg-white px-2.5 py-1 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
             >
               查看所有稅額組合
             </button>

--- a/src/components/checklist/ChecklistInlineAmountFields.tsx
+++ b/src/components/checklist/ChecklistInlineAmountFields.tsx
@@ -278,42 +278,40 @@ function ExemptionAgeRow({
   return (
     <fieldset className="border-0 p-0">
       <legend className="sr-only">{field.label}</legend>
-      <div className="grid gap-2 sm:grid-cols-[6rem_1fr] sm:items-center">
-        <div className="text-base font-medium text-gray-700" aria-hidden="true">{field.label}</div>
-        <div
-          className="flex flex-wrap gap-x-5 gap-y-2"
-          data-testid={`card-choice-exemption-general-${field.id}`}
-        >
-          {(field.choices ?? []).map((choice) => {
-            const selected = value === choice.value
-            return (
-              <label
-                key={choice.value}
-                className="flex min-h-10 cursor-pointer items-center gap-2 text-base text-gray-800"
+      <div className="text-base font-medium text-gray-600" aria-hidden="true">{field.label}</div>
+      <div
+        className="mt-1 flex flex-wrap gap-x-5 gap-y-2"
+        data-testid={`card-choice-exemption-general-${field.id}`}
+      >
+        {(field.choices ?? []).map((choice) => {
+          const selected = value === choice.value
+          return (
+            <label
+              key={choice.value}
+              className="flex min-h-10 cursor-pointer items-center gap-2 text-base text-gray-700"
+            >
+              <input
+                type="radio"
+                name={`exemption-general-${field.id}`}
+                value={choice.value}
+                checked={selected}
+                onChange={() => onInputChange?.(field.id, choice.value)}
+                data-testid={`card-choice-exemption-general-${field.id}-${choice.value}`}
+                className="peer sr-only"
+              />
+              <span
+                className={[
+                  'flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-blue-500 peer-focus-visible:ring-offset-2',
+                  selected ? 'border-blue-600 bg-blue-600' : 'border-gray-300 bg-white',
+                ].join(' ')}
+                aria-hidden="true"
               >
-                <input
-                  type="radio"
-                  name={`exemption-general-${field.id}`}
-                  value={choice.value}
-                  checked={selected}
-                  onChange={() => onInputChange?.(field.id, choice.value)}
-                  data-testid={`card-choice-exemption-general-${field.id}-${choice.value}`}
-                  className="peer sr-only"
-                />
-                <span
-                  className={[
-                    'flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-blue-500 peer-focus-visible:ring-offset-2',
-                    selected ? 'border-blue-600 bg-blue-600' : 'border-gray-300 bg-white',
-                  ].join(' ')}
-                  aria-hidden="true"
-                >
-                  {selected && <span className="h-1.5 w-1.5 rounded-full bg-white" />}
-                </span>
-                <span className="font-medium">{choice.label}</span>
-              </label>
-            )
-          })}
-        </div>
+                {selected && <span className="h-1.5 w-1.5 rounded-full bg-white" />}
+              </span>
+              <span className="font-medium text-gray-700">{choice.label}</span>
+            </label>
+          )
+        })}
       </div>
     </fieldset>
   )
@@ -331,9 +329,7 @@ function ExemptionDependentCountRow({
   onInputChange?: (fieldId: string, value: string) => void
 }) {
   return (
-    <label className="grid gap-2 sm:grid-cols-[6rem_1fr] sm:items-center">
-      <span className="text-base font-medium text-gray-700">其他親屬</span>
-      <span className="flex flex-wrap items-center gap-2 text-base text-gray-700">
+    <label className="flex flex-wrap items-center gap-2 text-base text-gray-700">
         <span className="min-w-20 font-medium">{label}</span>
         <input
           type="number"
@@ -346,7 +342,6 @@ function ExemptionDependentCountRow({
           placeholder="0"
         />
         <span className="text-gray-500">人</span>
-      </span>
     </label>
   )
 }
@@ -366,7 +361,7 @@ function ExemptionGeneralInlineFields({
   const over70CountField = findInlineField(inlineFields, 'exemption_over70_count')
 
   return (
-    <div className="mt-3 space-y-2 rounded-xl border border-gray-300 bg-gray-100/70 p-3">
+    <div className="mt-3 space-y-3 rounded-xl border border-gray-300 bg-gray-100/70 p-3">
       {selfAgeField && (
         <ExemptionAgeRow
           field={selfAgeField}
@@ -381,21 +376,26 @@ function ExemptionGeneralInlineFields({
           onInputChange={onInputChange}
         />
       )}
-      {under70CountField && (
-        <ExemptionDependentCountRow
-          field={under70CountField}
-          label="未滿 70 歲"
-          value={inputValues[under70CountField.id] ?? ''}
-          onInputChange={onInputChange}
-        />
-      )}
-      {over70CountField && (
-        <ExemptionDependentCountRow
-          field={over70CountField}
-          label="70 歲以上"
-          value={inputValues[over70CountField.id] ?? ''}
-          onInputChange={onInputChange}
-        />
+      {(under70CountField || over70CountField) && (
+        <div className="space-y-2">
+          <div className="text-base font-medium text-gray-600">其他親屬</div>
+          {under70CountField && (
+            <ExemptionDependentCountRow
+              field={under70CountField}
+              label="未滿 70 歲"
+              value={inputValues[under70CountField.id] ?? ''}
+              onInputChange={onInputChange}
+            />
+          )}
+          {over70CountField && (
+            <ExemptionDependentCountRow
+              field={over70CountField}
+              label="70 歲以上"
+              value={inputValues[over70CountField.id] ?? ''}
+              onInputChange={onInputChange}
+            />
+          )}
+        </div>
       )}
     </div>
   )

--- a/tests/checklist.test.ts
+++ b/tests/checklist.test.ts
@@ -434,6 +434,13 @@ describe('ChecklistResult standard vs itemized filing reminder panel', () => {
     expect(summary).not.toContain('所得淨額')
   })
 
+  it('shows incomplete tax hint with finalized recommendation copy when tax cannot be calculated yet', () => {
+    const html = renderResult(['salary_income'])
+    expect(html).toContain('data-testid="tax-result-incomplete-hint"')
+    expect(html).toContain('填寫完畢後，將推薦稅額組合')
+    expect(html).not.toContain('待計算')
+  })
+
   it('shows overseas income amount without including overseas tax paid in summary', () => {
     const html = renderResult(['salary_income', 'overseas_income'], {
       'overseas-income-amt': {
@@ -1092,7 +1099,7 @@ describe('DeductionCard inline input fields', () => {
     expect(html).toContain('aria-pressed="true"')
   })
 
-  it('renders exemption inputs as four compact rows with native radio controls', () => {
+  it('renders exemption inputs with stacked age rows and a single dependent heading', () => {
     const html = renderToStaticMarkup(
       createElement(DeductionCard, {
         item: makeItem({ id: 'exemption-general' }),
@@ -1110,9 +1117,12 @@ describe('DeductionCard inline input fields', () => {
     expect(html).toContain('name="exemption-general-spouse_age_band"')
     expect(html).toContain('checked=""')
     expect(html).toContain('peer-focus-visible:ring-2')
+    expect(html).toContain('data-testid="card-choice-exemption-general-self_age_band"')
+    expect(html).toContain('data-testid="card-choice-exemption-general-spouse_age_band"')
     expect(html).toContain('本人年齡')
     expect(html).toContain('配偶年齡')
     expect(html).toContain('其他親屬')
+    expect((html.match(/其他親屬/g) ?? []).length).toBe(1)
     expect(html).toContain('data-testid="card-input-exemption-general-exemption_under70_count"')
     expect(html).toContain('data-testid="card-input-exemption-general-exemption_over70_count"')
     expect(html).not.toContain('一般免稅額人數（未滿 70 歲）')

--- a/tests/situation-single-source-flow.test.tsx
+++ b/tests/situation-single-source-flow.test.tsx
@@ -956,6 +956,21 @@ describe('situation single-source flow', () => {
     expect(container.querySelector('[data-testid="gross-income-dividend-scenarios"]')).toBeNull()
   })
 
+  it('shows incomplete tax hint before required fields are filled and removes it after completion', () => {
+    renderApp()
+    clickButtonByText('薪資收入')
+    clickButtonByText('產生節稅清單')
+
+    const hint = container.querySelector<HTMLElement>('[data-testid="tax-result-incomplete-hint"]')
+    expect(hint?.textContent).toContain('填寫完畢後，將推薦稅額組合')
+    expect(container.textContent).not.toContain('尚未完成')
+
+    changeInputByTestId('income-input-gross-income-self', '300000')
+    clickByTestId('card-choice-exemption-general-self_age_band-under_70')
+
+    expect(container.querySelector('[data-testid="tax-result-incomplete-hint"]')).toBeNull()
+  })
+
   it('shows filing mode without recommendation prefix when there is only one tax scenario', () => {
     renderApp()
     clickButtonByText('薪資收入')
@@ -974,7 +989,7 @@ describe('situation single-source flow', () => {
     const dialog = getLatestScenarioDialog()
     expect(dialog?.textContent).toContain('單身申報')
     expect(dialog?.textContent).not.toContain('推薦')
-    expect(getScenarioDialogHeaders()).toEqual(['申報組合', '最終稅額', ''])
+    expect(getScenarioDialogHeaders()).toEqual(['申報組合', '應繳納稅額', ''])
 
     // single scenario auto-expands, so formula content is visible immediately
     expect(dialog?.textContent).toContain('所得計算')
@@ -994,7 +1009,7 @@ describe('situation single-source flow', () => {
     clickByTestId('card-choice-exemption-general-spouse_age_band-under_70')
     clickButtonByText('查看所有稅額組合')
 
-    expect(getScenarioDialogHeaders()).toEqual(['申報組合', '配偶計稅方式', '最終稅額', ''])
+    expect(getScenarioDialogHeaders()).toEqual(['申報組合', '配偶計稅方式', '應繳納稅額', ''])
 
     clickLatestScenarioDialogByTestId('scenario-row-spouse_salary_separate:none')
     const splitSections = document.body.querySelector<HTMLElement>('[data-testid="scenario-formula-sections-spouse_salary_separate:none"]')


### PR DESCRIPTION
## Summary
When tax cannot yet be calculated, show an `IncompleteTaxHint` component
(star icon + "填寫完畢後，將推薦稅額組合") instead of the "待計算" inline
text. Also removes the bordered box wrapper from TaxResultBody, renames
the scenario dialog column header "最終稅額" → "應繳納稅額", and reskins
the "查看所有稅額組合" button from blue to gray.

Refactors ExemptionGeneralInlineFields: drops the 2-column grid layout,
stacks age-band rows under their own label, and consolidates the two
dependent-count rows under a single "其他親屬" heading to avoid duplicate
text.

Tests updated to cover the new hint element lifecycle and the renamed
column headers.


style: 以插圖空白狀態取代稅額「待計算」文字

尚無法計算稅額時，改顯示 `IncompleteTaxHint` 元件（星形圖示 +
「填寫完畢後，將推薦稅額組合」），取代原本的「待計算」行內文字，
並移除 TaxResultBody 的外框 border。情境對話框欄位標題
「最終稅額」同步改為「應繳納稅額」；「查看所有稅額組合」按鈕
樣式由藍色調整為灰色。

重構 ExemptionGeneralInlineFields：移除二欄 grid 版型，
年齡選項改為垂直堆疊；兩個親屬人數欄位整合至單一「其他親屬」
標題下，避免文字重複出現。

更新測試，涵蓋提示元件的顯示與消失邏輯，及欄位標題更名的驗證。

## Checks

- [x] No personal tax data or private documents included
- [x] Tax-related claims are sourced or marked as draft
- [x] Changes are scoped to this PR
