### PR TITLE
fix: filter rate-tiered offers below minimum threshold

### DIFF
--- a/src/lib/paymentOffers.ts
+++ b/src/lib/paymentOffers.ts
@@ -186,7 +186,17 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
 
   if (o.mode === 'rate-tiered' && o.amount_tiers && o.amount_tiers.length > 0) {
     const tiers = [...o.amount_tiers].sort((a, b) => b.min - a.min)
-    const t = tiers.find((x) => amount >= x.min) ?? tiers[tiers.length - 1]
+    const matched = tiers.find((x) => amount >= x.min)
+    if (!matched && amount > 0) {
+      const lowestMin = tiers[tiers.length - 1].min
+      return {
+        applicable: false,
+        value: 0,
+        kind: o.mode,
+        reason: `需單筆滿 ${fmtNT(lowestMin)}`,
+      }
+    }
+    const t = matched ?? tiers[tiers.length - 1]
 
     if (t.kind === 'fixed') {
       const raw = t.fixed

--- a/tests/paymentOffers.test.ts
+++ b/tests/paymentOffers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { filterOffersByCards, loadOffers } from '../src/lib/paymentOffers'
+import { filterOffersByCards, loadOffers, resolveOffer } from '../src/lib/paymentOffers'
 
 const offers = loadOffers()
 
@@ -66,6 +66,44 @@ describe('filterOffersByCards 契約', () => {
     const out = filterOffersByCards(offers, new Set(['bank999_unknown']))
     // 未知 id 不對應任何 bank，全卡別 campaign 全不命中；限定卡也不命中
     expect(out.length).toBe(0)
+  })
+})
+
+describe('resolveOffer rate-tiered 門檻過濾', () => {
+  it('金額低於所有 tier 最低門檻時 applicable = false', () => {
+    const tiered = offers.find(
+      (o) => o.mode === 'rate-tiered' &&
+        o.amount_tiers &&
+        o.amount_tiers.length > 0 &&
+        Math.min(...o.amount_tiers.map((t) => t.min)) > 0,
+    )
+    expect(tiered).toBeTruthy()
+    const lowestMin = Math.min(...tiered!.amount_tiers!.map((t) => t.min))
+    const r = resolveOffer(tiered!, lowestMin - 1)
+    expect(r.applicable).toBe(false)
+    expect(r.reason).toBeTruthy()
+  })
+
+  it('金額達到 tier 門檻時 applicable = true', () => {
+    const tiered = offers.find(
+      (o) => o.mode === 'rate-tiered' && o.amount_tiers && o.amount_tiers.length > 0,
+    )
+    expect(tiered).toBeTruthy()
+    const highestMin = Math.max(...tiered!.amount_tiers!.map((t) => t.min))
+    const r = resolveOffer(tiered!, highestMin)
+    expect(r.applicable).toBe(true)
+  })
+
+  it('金額為 0 時 tiered offer 仍顯示（尚未輸入）', () => {
+    const tiered = offers.find(
+      (o) => o.mode === 'rate-tiered' &&
+        o.amount_tiers &&
+        o.amount_tiers.length > 0 &&
+        Math.min(...o.amount_tiers.map((t) => t.min)) > 0,
+    )
+    expect(tiered).toBeTruthy()
+    const r = resolveOffer(tiered!, 0)
+    expect(r.applicable).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Problem

`rate-tiered` payment offers with no zero-base tier (e.g. CTBC mileage bonus requiring NT$10M+) were displayed as applicable regardless of the user's entered amount.

**Root cause:** `resolveOffer()` unconditionally fell back to the lowest tier when no tier matched, always returning `applicable: true`.

**Affected offers:**

| Bank | Campaign | Lowest tier min |
|------|----------|----------------|
| 中國信託 | 高稅額｜華航哩程加碼 | NT$10,000,000 |
| 中華郵政 | VIP 回饋 | NT$500,000 |
| 永豐銀行 | 台灣Pay 回饋 | NT$1,000 |

## Fix

When `amount > 0` and no tier threshold is met, return `applicable: false` with a reason string. Preserves the existing behaviour at `amount === 0` (show all offers before the user enters a value), consistent with the non-tiered `min` check.

## Tests

- Amount below all tier minimums → `applicable: false`
- Amount meeting a tier → `applicable: true`
- Amount = 0 → `applicable: true` (pre-input state)