### PR TITLE
fix(payment): normalize reward values to NTD before sorting

### DIFF
--- a/src/components/payment/OfferRow.tsx
+++ b/src/components/payment/OfferRow.tsx
@@ -1,6 +1,7 @@
 import { ExternalLink, Info } from 'lucide-react'
 import { Card } from '../ui/Card'
 import { fmtNT, fmtPct, resolveOffer } from '../../lib/paymentOffers'
+import { getUnitMeta, ratioHintText } from '../../lib/rewardUnits'
 import type { Offer, OfferTag } from '../../types/paymentOffers'
 
 interface OfferRowProps {
@@ -46,6 +47,12 @@ export function OfferRow({ offer, rank, amount, isTop }: OfferRowProps) {
 
   // Headline number
   const isNTUnit = !r.unit || r.unit === '元'
+  const unitMeta = getUnitMeta(r.unit)
+  const showNtdHint =
+    unitMeta.kind === 'cash_equivalent' &&
+    r.value_ntd != null &&
+    r.value_ntd > 0 &&
+    !isNTUnit
   const formatValue = (v: number) =>
     isNTUnit ? fmtNT(v) : Math.round(v).toLocaleString('zh-TW')
   let headline: React.ReactNode
@@ -133,6 +140,15 @@ export function OfferRow({ offer, rank, amount, isTop }: OfferRowProps) {
               </p>
               <div className="min-w-0">
                 {headline}
+                {showNtdHint && (
+                  <p className="text-base text-gray-500 mt-0.5 tabular-nums">
+                    ≈ {fmtNT(r.value_ntd!)}
+                    {(() => {
+                      const hint = ratioHintText(r.unit)
+                      return hint ? <span className="ml-1 text-gray-400">（{hint}）</span> : null
+                    })()}
+                  </p>
+                )}
                 {r.capped && (
                   <p className="text-base text-amber-700 mt-1">
                     已達上限 {r.cap != null ? formatValue(r.cap) : '—'}

--- a/src/components/payment/ResultList.tsx
+++ b/src/components/payment/ResultList.tsx
@@ -7,6 +7,7 @@ import {
   fmtPct,
   resolveOffer,
 } from '../../lib/paymentOffers'
+import { getUnitMeta, ratioHintText } from '../../lib/rewardUnits'
 import type { Offer, ResolveResult } from '../../types/paymentOffers'
 import type { TypeFilterValue } from './TypeFilter'
 
@@ -26,8 +27,8 @@ interface RankedRow {
 
 function sortRanked(rows: RankedRow[]): RankedRow[] {
   return [...rows].sort((a, b) => {
-    const va = a.r.value ?? -1
-    const vb = b.r.value ?? -1
+    const va = a.r.value_ntd ?? -Infinity
+    const vb = b.r.value_ntd ?? -Infinity
     if (va !== vb) return vb - va
     const ba = a.o.bank
     const bb = b.o.bank
@@ -70,8 +71,8 @@ export function ResultList({
   const top = useMemo(() => {
     const pool = filtered
       .map((o) => ({ o, r: resolveOffer(o, amount) }))
-      .filter((x) => x.r.applicable && x.r.value != null && x.r.value > 0)
-      .sort((a, b) => (b.r.value ?? 0) - (a.r.value ?? 0))
+      .filter((x) => x.r.applicable && x.r.value_ntd != null && x.r.value_ntd > 0)
+      .sort((a, b) => (b.r.value_ntd ?? 0) - (a.r.value_ntd ?? 0))
     return pool[0]
   }, [filtered, amount])
 
@@ -100,6 +101,24 @@ export function ResultList({
                   return `${Math.round(top.r.value ?? 0).toLocaleString('zh-TW')} ${top.r.unit}`
                 })()}
               </span>
+              {(() => {
+                const isNTUnit = !top.r.unit || top.r.unit === '元'
+                const meta = getUnitMeta(top.r.unit)
+                if (
+                  isNTUnit ||
+                  meta.kind !== 'cash_equivalent' ||
+                  top.r.value_ntd == null ||
+                  top.r.value_ntd <= 0
+                )
+                  return null
+                const hint = ratioHintText(top.r.unit)
+                return (
+                  <span className="text-gray-500 ml-1 tabular-nums">
+                    （約 {fmtNT(top.r.value_ntd)}
+                    {hint ? `，${hint}` : ''}）
+                  </span>
+                )
+              })()}
               {top.r.rate != null && top.r.rate > 0 ? (
                 <span className="text-gray-500">
                   （回饋率 {fmtPct(top.r.rate)}

--- a/src/data/tax_payment_rewards_114.json
+++ b/src/data/tax_payment_rewards_114.json
@@ -1,6 +1,23 @@
 {
   "tax_year": "114",
   "schema_version": "v2.7",
+  "reward_units": {
+    "元": { "ntd_per_unit": 1, "kind": "face_value" },
+    "元刷卡金": { "ntd_per_unit": 1, "kind": "face_value" },
+    "元 SOGO 禮券": { "ntd_per_unit": 1, "kind": "face_value" },
+    "元即享券": { "ntd_per_unit": 1, "kind": "face_value" },
+    "元統一超商抵用券": { "ntd_per_unit": 1, "kind": "face_value" },
+    "元超商電子禮券": { "ntd_per_unit": 1, "kind": "face_value" },
+    "元電子禮券": { "ntd_per_unit": 1, "kind": "face_value" },
+    "點台灣 Pay 紅利": { "ntd_per_unit": 0.1, "kind": "cash_equivalent" },
+    "LINE POINTS": { "ntd_per_unit": 1, "kind": "cash_equivalent" },
+    "OPEN POINTS": { "ntd_per_unit": 1, "kind": "cash_equivalent" },
+    "小樹點": { "ntd_per_unit": 1, "kind": "cash_equivalent" },
+    "街口幣": { "ntd_per_unit": 1, "kind": "cash_equivalent" },
+    "e point": { "ntd_per_unit": 1, "kind": "cash_equivalent" },
+    "和泰 Points": { "ntd_per_unit": 1, "kind": "cash_equivalent" },
+    "哩": { "ntd_per_unit": 0.5, "kind": "cash_equivalent" }
+  },
   "banks": [
     {
       "bank_code": "004",

--- a/src/lib/paymentOffers.ts
+++ b/src/lib/paymentOffers.ts
@@ -3,6 +3,7 @@
 
 import rawData from '../data/tax_payment_rewards_114.json'
 import { getCard } from './cardCatalog'
+import { toNtd } from './rewardUnits'
 import type {
   AmountTier,
   BankListItem,
@@ -131,10 +132,10 @@ function toOffer(bank: RawBank, c: RawCampaign, mode: RebateMode): Offer {
 // ── resolveOffer（移植自原型 Personalized Comparison.html L54-92） ───────────
 export function resolveOffer(o: Offer, amount: number): ResolveResult {
   if (o.mode === 'installment_only') {
-    return { applicable: true, value: null, kind: 'installment_only' }
+    return { applicable: true, value: null, value_ntd: null, kind: 'installment_only' }
   }
   if (o.mode === 'fee_only') {
-    return { applicable: true, value: null, kind: 'fee_only' }
+    return { applicable: true, value: null, value_ntd: null, kind: 'fee_only' }
   }
 
   const min = o.min ?? null
@@ -142,6 +143,7 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
     return {
       applicable: false,
       value: 0,
+      value_ntd: 0,
       kind: o.mode,
       reason: `需單筆滿 ${fmtNT(min)}`,
     }
@@ -153,11 +155,14 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
       : null
 
   if (o.mode === 'fixed') {
+    const unit = o.fixed_unit ?? '元'
+    const value = o.fixed ?? null
     return {
       applicable: true,
       kind: 'fixed',
-      value: o.fixed ?? null,
-      unit: o.fixed_unit ?? '元',
+      value,
+      value_ntd: toNtd(value, unit),
+      unit,
       threshold_label: thresholdLabel,
     }
   }
@@ -172,14 +177,16 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
       value = o.cap_nt + (o.base_fixed ?? 0)
       capped = true
     }
+    const unit = o.fixed_unit ?? '元'
     return {
       applicable: true,
       kind: 'rate',
       value,
+      value_ntd: toNtd(value, unit),
       rate,
       capped,
       cap: o.cap_nt,
-      unit: o.fixed_unit ?? '元',
+      unit,
       threshold_label: thresholdLabel,
     }
   }
@@ -192,6 +199,7 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
       return {
         applicable: false,
         value: 0,
+        value_ntd: 0,
         kind: o.mode,
         reason: `需單筆滿 ${fmtNT(lowestMin)}`,
       }
@@ -202,10 +210,12 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
       const raw = t.fixed
       const cap = t.cap_nt ?? null
       const capped = cap != null && raw > cap
+      const value = capped ? cap : raw
       return {
         applicable: true,
         kind: 'rate-tiered',
-        value: capped ? cap : raw,
+        value,
+        value_ntd: toNtd(value, t.fixed_unit),
         capped,
         cap,
         tier_label: t.label,
@@ -215,19 +225,22 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
 
     const raw = (amount * t.rate) / 100
     const capped = t.cap_nt != null && raw > t.cap_nt
+    const value = capped ? t.cap_nt! : raw
+    const unit = o.fixed_unit ?? '元'
     return {
       applicable: true,
       kind: 'rate-tiered',
-      value: capped ? t.cap_nt! : raw,
+      value,
+      value_ntd: toNtd(value, unit),
       rate: t.rate,
       capped,
       cap: t.cap_nt,
       tier_label: t.label,
-      unit: o.fixed_unit ?? '元',
+      unit,
     }
   }
 
-  return { applicable: true, value: null, kind: o.mode }
+  return { applicable: true, value: null, value_ntd: null, kind: o.mode }
 }
 
 // ── 卡 picker 篩選契約 ──────────────────────────────────────────────────────

--- a/src/lib/rewardUnits.ts
+++ b/src/lib/rewardUnits.ts
@@ -1,0 +1,51 @@
+// 單位 → NT$ 換算與顯示策略。catalog 來源為 src/data/tax_payment_rewards_114.json
+// 的 reward_units 欄位，讓資料和換算規則同源維護。
+
+import rawData from '../data/tax_payment_rewards_114.json'
+
+export type RewardUnitKind = 'face_value' | 'cash_equivalent' | 'non_comparable'
+
+export interface RewardUnitMeta {
+  ntd_per_unit: number | null
+  kind: RewardUnitKind
+}
+
+const CATALOG: Record<string, RewardUnitMeta> =
+  (rawData as unknown as { reward_units?: Record<string, RewardUnitMeta> }).reward_units ?? {}
+
+const warned = new Set<string>()
+
+export function getUnitMeta(unit: string | undefined | null): RewardUnitMeta {
+  if (!unit) return { ntd_per_unit: 1, kind: 'face_value' }
+  const m = CATALOG[unit]
+  if (m) return m
+  if (import.meta.env.DEV && !warned.has(unit)) {
+    warned.add(unit)
+    console.warn(`[rewardUnits] unknown unit: ${unit}`)
+  }
+  return { ntd_per_unit: null, kind: 'non_comparable' }
+}
+
+export function toNtd(
+  value: number | null | undefined,
+  unit: string | undefined | null,
+): number | null {
+  if (value == null) return null
+  const { ntd_per_unit } = getUnitMeta(unit)
+  return ntd_per_unit == null ? null : value * ntd_per_unit
+}
+
+// 給「以 1 哩 ≈ NT$ 0.5 估算」這類比例顯示用，保留必要小數。
+export function fmtNtRatio(n: number): string {
+  const s = Number.isInteger(n) ? String(n) : n.toFixed(2).replace(/\.?0+$/, '')
+  return `NT$ ${s}`
+}
+
+// 「以 1 [單位] ≈ NT$ X 估算」的說明字串；ratio 為 1 時回 null（不顯示）。
+export function ratioHintText(unit: string | undefined | null): string | null {
+  const meta = getUnitMeta(unit)
+  if (meta.kind !== 'cash_equivalent' || meta.ntd_per_unit == null || meta.ntd_per_unit === 1) {
+    return null
+  }
+  return `以 1 ${unit} ≈ ${fmtNtRatio(meta.ntd_per_unit)} 估算`
+}

--- a/src/types/paymentOffers.ts
+++ b/src/types/paymentOffers.ts
@@ -76,6 +76,7 @@ export interface ResolveResult {
   applicable: boolean
   kind: RebateMode
   value: number | null          // 估算回饋金額；null 表示無金額（如僅分期）
+  value_ntd: number | null      // 排序與輔助顯示用 NT$ 等值；非「官方回饋金額」
   rate?: number                 // 適用回饋率
   capped?: boolean              // 是否觸發上限
   cap?: number | null

--- a/tests/rewardUnits.test.ts
+++ b/tests/rewardUnits.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest'
+import { fmtNtRatio, getUnitMeta, toNtd } from '../src/lib/rewardUnits'
+import { loadOffers, resolveOffer } from '../src/lib/paymentOffers'
+import rawData from '../src/data/tax_payment_rewards_114.json'
+
+describe('toNtd', () => {
+  it('台灣 Pay 紅利 10:1 → 600 點 = NT$60', () => {
+    expect(toNtd(600, '點台灣 Pay 紅利')).toBe(60)
+  })
+
+  it('元刷卡金 = 1:1', () => {
+    expect(toNtd(60, '元刷卡金')).toBe(60)
+  })
+
+  it('哩 = NT$0.5/哩', () => {
+    expect(toNtd(600, '哩')).toBe(300)
+  })
+
+  it('未知單位 → null', () => {
+    expect(toNtd(123, '未來新單位')).toBeNull()
+  })
+
+  it('undefined unit → 視為 NT$', () => {
+    expect(toNtd(50, undefined)).toBe(50)
+    expect(toNtd(50, '元')).toBe(50)
+  })
+
+  it('value 為 null/undefined → null', () => {
+    expect(toNtd(null, '元')).toBeNull()
+    expect(toNtd(undefined, '元')).toBeNull()
+  })
+})
+
+describe('getUnitMeta', () => {
+  it('元刷卡金 → face_value', () => {
+    expect(getUnitMeta('元刷卡金').kind).toBe('face_value')
+  })
+  it('點台灣 Pay 紅利 → cash_equivalent', () => {
+    expect(getUnitMeta('點台灣 Pay 紅利').kind).toBe('cash_equivalent')
+  })
+  it('哩 → cash_equivalent', () => {
+    const m = getUnitMeta('哩')
+    expect(m.kind).toBe('cash_equivalent')
+    expect(m.ntd_per_unit).toBe(0.5)
+  })
+  it('未知單位 → non_comparable + ntd_per_unit null', () => {
+    const m = getUnitMeta('未來新單位')
+    expect(m.kind).toBe('non_comparable')
+    expect(m.ntd_per_unit).toBeNull()
+  })
+})
+
+describe('fmtNtRatio', () => {
+  it('整數不顯示小數', () => {
+    expect(fmtNtRatio(1)).toBe('NT$ 1')
+  })
+  it('保留必要小數', () => {
+    expect(fmtNtRatio(0.5)).toBe('NT$ 0.5')
+    expect(fmtNtRatio(0.1)).toBe('NT$ 0.1')
+  })
+})
+
+describe('資料完整性：JSON 內所有 fixed_unit 必須在 catalog', () => {
+  const catalog = (
+    rawData as unknown as {
+      reward_units: Record<string, { ntd_per_unit: number | null; kind: string }>
+    }
+  ).reward_units
+
+  it('catalog 存在且非空', () => {
+    expect(catalog).toBeTruthy()
+    expect(Object.keys(catalog).length).toBeGreaterThan(0)
+  })
+
+  it('每個 fixed_unit / amount_tiers[].fixed_unit 都已登錄', () => {
+    const seen = new Set<string>()
+    for (const offer of loadOffers()) {
+      if (offer.fixed_unit) seen.add(offer.fixed_unit)
+      for (const t of offer.amount_tiers ?? []) {
+        if (t.kind === 'fixed' && t.fixed_unit) seen.add(t.fixed_unit)
+      }
+    }
+    const missing = [...seen].filter((u) => !(u in catalog))
+    expect(missing, `Units missing from reward_units catalog: ${missing.join(', ')}`).toEqual(
+      [],
+    )
+  })
+
+  it('catalog 每個 entry 的 kind 與 ntd_per_unit 格式合法', () => {
+    const validKinds = new Set(['face_value', 'cash_equivalent', 'non_comparable'])
+    for (const [unit, meta] of Object.entries(catalog)) {
+      expect(validKinds.has(meta.kind), `${unit} kind=${meta.kind}`).toBe(true)
+      if (meta.kind === 'non_comparable') {
+        expect(meta.ntd_per_unit, `${unit} non_comparable 應為 null`).toBeNull()
+      } else {
+        expect(typeof meta.ntd_per_unit, `${unit} 需數字`).toBe('number')
+        expect(Number.isFinite(meta.ntd_per_unit), `${unit} 需 finite`).toBe(true)
+        expect(meta.ntd_per_unit, `${unit} 需 > 0`).toBeGreaterThan(0)
+      }
+    }
+  })
+})
+
+describe('resolveOffer value_ntd', () => {
+  const offers = loadOffers()
+
+  it('fixed 模式：value_ntd 反映 unit 換算', () => {
+    const twPay = offers.find(
+      (o) => o.mode === 'fixed' && o.fixed_unit === '點台灣 Pay 紅利',
+    )
+    expect(twPay, '需有 fixed_unit=點台灣 Pay 紅利 的 offer').toBeTruthy()
+    const r = resolveOffer(twPay!, 60000)
+    expect(r.value).toBe(twPay!.fixed)
+    expect(r.value_ntd).toBe((twPay!.fixed ?? 0) * 0.1)
+  })
+
+  it('rate 模式：value_ntd = value（NT$）', () => {
+    const rate = offers.find((o) => o.mode === 'rate')
+    expect(rate, '需有 rate offer').toBeTruthy()
+    const r = resolveOffer(rate!, 60000)
+    expect(r.value_ntd).toBe(r.value)
+  })
+
+  it('installment_only / fee_only：value_ntd = null', () => {
+    const inst = offers.find((o) => o.mode === 'installment_only')
+    if (inst) {
+      const r = resolveOffer(inst, 60000)
+      expect(r.value_ntd).toBeNull()
+    }
+    const fee = offers.find((o) => o.mode === 'fee_only')
+    if (fee) {
+      const r = resolveOffer(fee, 60000)
+      expect(r.value_ntd).toBeNull()
+    }
+  })
+})
+
+describe('排序：依 NT$ 等值排，而非原始 value', () => {
+  // 對應原 bug：600 點台灣 Pay 紅利 (≈ NT$60) 不應排到 100 元刷卡金之前。
+  // 構造 mock ResolveResult 走真實的 sort 比較邏輯（與 ResultList.sortRanked 同義）。
+  function sortByNtd<T extends { value_ntd: number | null }>(rows: T[]): T[] {
+    return [...rows].sort((a, b) => {
+      const va = a.value_ntd ?? -Infinity
+      const vb = b.value_ntd ?? -Infinity
+      return vb - va
+    })
+  }
+
+  it('600 點台灣 Pay 紅利 (≈NT$60) 排在 NT$100 刷卡金之後', () => {
+    const twPay = { id: 'twPay', value: 600, value_ntd: toNtd(600, '點台灣 Pay 紅利') }
+    const card = { id: 'card', value: 100, value_ntd: toNtd(100, '元刷卡金') }
+    const sorted = sortByNtd([twPay, card])
+    expect(sorted[0].id).toBe('card')
+    expect(sorted[1].id).toBe('twPay')
+  })
+
+  it('600 哩 (≈NT$300) 排在 NT$100 刷卡金之前', () => {
+    const mile = { id: 'mile', value: 600, value_ntd: toNtd(600, '哩') }
+    const card = { id: 'card', value: 100, value_ntd: toNtd(100, '元刷卡金') }
+    const sorted = sortByNtd([mile, card])
+    expect(sorted[0].id).toBe('mile')
+  })
+
+  it('value_ntd = null 的方案排到最後', () => {
+    const unknown = { id: 'unknown', value: 999, value_ntd: null }
+    const card = { id: 'card', value: 1, value_ntd: 1 }
+    const sorted = sortByNtd([unknown, card])
+    expect(sorted[0].id).toBe('card')
+    expect(sorted[1].id).toBe('unknown')
+  })
+})


### PR DESCRIPTION
## Summary
Add reward_units catalog to the JSON data layer to centralize unit-to-NTD conversion ratios and display strategies (face_value / cash_equivalent). resolveOffer now populates value_ntd on every result; sortRanked and the top-offer banner compare by value_ntd instead of raw value, so units like Taiwan Pay points (10:1) and miles (0.5 NTD/mile) rank correctly. Non-1:1 units show an "≈ NT$ X (est. 1 [unit] ≈ NT$ Y)" hint in OfferRow and the top banner.
