### PR TITLE
fix(payment): correct Taishin Richart/JCB bonus campaign and 808 PxPay rate

### DIFF
--- a/src/data/tax_payment_rewards_114.json
+++ b/src/data/tax_payment_rewards_114.json
@@ -2427,7 +2427,7 @@
             "summary": "不限金額享 3／6 期 0 利率；滿 120,000 元享 12 期 0 利率",
             "min_amount": null
           },
-          "notes": "回饋與 0 利率分期可並用，須分別登錄；Richart 萬事達卡、JCB 全卡單筆滿 20 萬可加碼至 0.5%；限信用卡固定額度內；行動支付／超商繳稅不適用",
+          "notes": "回饋與 0 利率分期可並用，須分別登錄；Richart 萬事達卡、JCB 全卡單筆滿 20 萬之加碼 0.1% 另列為獨立方案（campaign_id: richart_jcb_single_tx_bonus）；限信用卡固定額度內；行動支付／超商繳稅不適用",
           "tags": [
             "credit_card",
             "installment"
@@ -2458,7 +2458,40 @@
             "cap_label": "每名持卡人合計上限 2,000 元"
           },
           "installment": null,
-          "notes": "與一般卡友 0 利率分期擇一，同時登錄以分期為準；Richart 萬事達卡、JCB 全卡單筆滿 20 萬可再加碼 0.1%，加碼上限 100,000 元；預計 2026/9/30 前入帳。",
+          "notes": "與一般卡友 0 利率分期擇一，同時登錄以分期為準；Richart 萬事達卡、JCB 全卡單筆滿 20 萬之加碼 0.1% 另列為獨立方案（campaign_id: richart_jcb_single_tx_bonus）；預計 2026/9/30 前入帳。",
+          "tags": [
+            "credit_card"
+          ]
+        },
+        {
+          "campaign_id": "richart_jcb_single_tx_bonus",
+          "title": "Richart 萬事達卡／JCB 全卡｜單筆滿 20 萬加碼",
+          "source_url": "https://mkp.taishinbank.com.tw/s/2026/tax/index.html",
+          "source_url_alt": "https://www.taishinbank.com.tw/TSB/personal/common/news/TSBankNews-007976/",
+          "source_id": null,
+          "eligible_cards": "Richart 萬事達卡、JCB 全卡（私銀／財管及一般卡友皆適用）",
+          "eligible_card_types": [
+            "credit"
+          ],
+          "eligible_card_ids": [
+            "bank812_richart_mastercard",
+            "bank812_jcb"
+          ],
+          "channel": [
+            "財政部網路繳稅服務網（Paytax）"
+          ],
+          "rebate": {
+            "requires_registration": true,
+            "period": "繳稅 2026/5/1~2026/6/4；登錄 2026/4/1 10:00–6/5 23:59",
+            "mode": "rate",
+            "rate": 0.1,
+            "fixed_unit": "元",
+            "min": 200000,
+            "cap_nt": 100000,
+            "cap_label": "加碼上限 100,000 元（與基礎回饋上限分開計算）"
+          },
+          "installment": null,
+          "notes": "可與台新基礎回饋（私銀 0.4% 或一般 0.1%）併計，加碼上限 100,000 元獨立於基礎回饋上限；單筆繳稅滿 20 萬才適用",
           "tags": [
             "credit_card"
           ]

--- a/src/data/tax_payment_rewards_114.json
+++ b/src/data/tax_payment_rewards_114.json
@@ -2236,14 +2236,14 @@
             "requires_registration": false,
             "period": "2026/5/1~2026/6/4",
             "mode": "rate",
-            "rate": 1,
+            "rate": 0.5,
             "fixed_unit": "元",
             "min": null,
             "cap_nt": 500,
             "cap_label": "玉山 0.5% 上限 500 點；首綁加碼 50 點"
           },
           "installment": null,
-          "notes": "不適用玉山官網繳稅分期優惠。綁卡繳稅成功後無法取消變更。最高約 1% 含首綁加碼（全支付活動）。",
+          "notes": "不適用玉山官網繳稅分期優惠。綁卡繳稅成功後無法取消變更。",
           "tags": [
             "credit_card"
           ]


### PR DESCRIPTION
## Summary

Two data fixes to `src/data/tax_payment_rewards_114.json`:

### 1. Add missing Taishin Richart/JCB bonus campaign (bank 812)

The official 2026 income-tax promotion includes a +0.1% bonus rebate
(capped at NT$100,000, separate from the base cap) for **Richart
Mastercard** and **JCB** cardholders on single transactions ≥ NT$200,000.
This rule was only described in prose inside two `notes` fields and never
reached the calculator.

Adds a new campaign `richart_jcb_single_tx_bonus` scoped to
`bank812_richart_mastercard` and `bank812_jcb` via `eligible_card_ids`, so
`filterOffersByCards` surfaces it only for those cards. `resolveOffer`
gates it at `min: 200000` and enforces `cap_nt: 100000` independently from
the base rebate cap (NT$100,000 for private banking / NT$2,000 for general
cardholders).

### 2. Fix 808 PxPay reward rate

Corrected the reward rate from `1` → `0.5` (matching the actual 0.5%
promotion) and removed an inaccurate note that cited a c