### PR TITLE
feat(payment-filter): add eligibility exclusion toggles (新戶身分 / 特殊會員)

### DIFF
--- a/src/components/PaymentRewardsPage.tsx
+++ b/src/components/PaymentRewardsPage.tsx
@@ -4,6 +4,8 @@ import { PageHeading } from './ui/PageHeading'
 import { AmountInput } from './payment/AmountInput'
 import { TypeFilter } from './payment/TypeFilter'
 import type { TypeFilterValue } from './payment/TypeFilter'
+import { ExcludeFilter } from './payment/ExcludeFilter'
+import type { ExcludeFilterValue } from './payment/ExcludeFilter'
 import { CardPicker } from './payment/CardPicker'
 import { ResultList } from './payment/ResultList'
 import { loadOffers } from '../lib/paymentOffers'
@@ -13,6 +15,7 @@ const LS_KEY = 'tax.payment.rewards.v2'
 interface SavedState {
   amount?: number
   typeFilter?: TypeFilterValue
+  excludeFilter?: ExcludeFilterValue
   selectedCardIds?: string[]
 }
 
@@ -31,6 +34,11 @@ const DEFAULT_TYPE_FILTER: TypeFilterValue = {
   credit_card: true,
   debit_card: true,
   installment: true,
+}
+
+const DEFAULT_EXCLUDE_FILTER: ExcludeFilterValue = {
+  newCustomer: false,
+  specialMember: false,
 }
 
 function AmountEmptyState() {
@@ -95,6 +103,10 @@ export function PaymentRewardsPage() {
     ...DEFAULT_TYPE_FILTER,
     ...(saved?.typeFilter ?? {}),
   }))
+  const [excludeFilter, setExcludeFilter] = useState<ExcludeFilterValue>(() => ({
+    ...DEFAULT_EXCLUDE_FILTER,
+    ...(saved?.excludeFilter ?? {}),
+  }))
   const [selectedCardIds, setSelectedCardIds] = useState<Set<string>>(
     () => new Set(saved?.selectedCardIds ?? []),
   )
@@ -105,13 +117,14 @@ export function PaymentRewardsPage() {
       const payload: SavedState = {
         amount,
         typeFilter,
+        excludeFilter,
         selectedCardIds: Array.from(selectedCardIds),
       }
       localStorage.setItem(LS_KEY, JSON.stringify(payload))
     } catch {
       // localStorage unavailable
     }
-  }, [amount, typeFilter, selectedCardIds])
+  }, [amount, typeFilter, excludeFilter, selectedCardIds])
 
   const anyType = Object.values(typeFilter).some(Boolean)
 
@@ -131,7 +144,10 @@ export function PaymentRewardsPage() {
         <>
           <section className="bg-white rounded-xl border border-gray-200 p-5 mb-6">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-5 items-start">
-              <TypeFilter value={typeFilter} onChange={setTypeFilter} />
+              <div className="flex flex-col gap-3">
+                <TypeFilter value={typeFilter} onChange={setTypeFilter} />
+                <ExcludeFilter value={excludeFilter} onChange={setExcludeFilter} />
+              </div>
               <CardPicker value={selectedCardIds} onChange={setSelectedCardIds} />
             </div>
           </section>
@@ -141,6 +157,7 @@ export function PaymentRewardsPage() {
               offers={offers}
               amount={amount}
               typeFilter={typeFilter}
+              excludeFilter={excludeFilter}
               selectedCardIds={selectedCardIds}
               query={query}
               onQueryChange={setQuery}

--- a/src/components/payment/ExcludeFilter.tsx
+++ b/src/components/payment/ExcludeFilter.tsx
@@ -1,0 +1,55 @@
+import { Check } from 'lucide-react'
+
+export interface ExcludeFilterValue {
+  newCustomer: boolean
+  specialMember: boolean
+}
+
+const ITEMS: Array<{ key: keyof ExcludeFilterValue; label: string }> = [
+  { key: 'newCustomer', label: '排除新戶身分' },
+  { key: 'specialMember', label: '排除銀行特殊會員' },
+]
+
+interface ExcludeFilterProps {
+  value: ExcludeFilterValue
+  onChange: (next: ExcludeFilterValue) => void
+}
+
+export function ExcludeFilter({ value, onChange }: ExcludeFilterProps) {
+  function toggle(k: keyof ExcludeFilterValue) {
+    onChange({ ...value, [k]: !value[k] })
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {ITEMS.map(({ key, label }) => {
+        const on = value[key]
+        return (
+          <button
+            key={key}
+            type="button"
+            role="switch"
+            aria-checked={on}
+            onClick={() => toggle(key)}
+            className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-2.5 text-base transition-colors ${
+              on
+                ? 'bg-blue-600 text-white border-blue-600 hover:bg-blue-700'
+                : 'bg-white text-gray-500 border-gray-200 hover:text-gray-900'
+            }`}
+          >
+            <span
+              className={`w-3.5 h-3.5 rounded border flex items-center justify-center transition-colors ${
+                on
+                  ? 'bg-white border-white text-blue-600'
+                  : 'bg-white border-gray-300 text-transparent'
+              }`}
+            >
+              <Check size={9} />
+            </span>
+            <span>{label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/payment/OfferRow.tsx
+++ b/src/components/payment/OfferRow.tsx
@@ -36,7 +36,8 @@ export function OfferRow({ offer, rank, amount, isTop }: OfferRowProps) {
   const isInstallmentOnly = r.kind === 'installment_only'
   const isFeeOnly = r.kind === 'fee_only'
   const isFixed = r.kind === 'fixed'
-  const isRebate = r.kind === 'rate' || r.kind === 'rate-tiered'
+  const isRebate =
+    r.kind === 'rate' || r.kind === 'rate-tiered' || r.kind === 'unit_per_amount'
   const highlightHeadline = isTop && r.value != null && r.value > 0
 
   const rankCls = isTop
@@ -89,6 +90,13 @@ export function OfferRow({ offer, rank, amount, isTop }: OfferRowProps) {
   const rateLabel = (() => {
     if (isInstallmentOnly || isFeeOnly) return '—'
     if (offer.mode === 'fixed') return '固定金額'
+    if (offer.mode === 'unit_per_amount') {
+      const per = offer.per_amount
+      const step = offer.fixed
+      const unit = offer.fixed_unit
+      if (per && step && unit) return `每 ${per.toLocaleString('zh-TW')} 元 ${step} ${unit}`
+      return offer.cap_label ?? '—'
+    }
     return fmtPct(r.rate ?? offer.rate ?? null)
   })()
 

--- a/src/components/payment/ResultList.tsx
+++ b/src/components/payment/ResultList.tsx
@@ -10,11 +10,13 @@ import {
 import { getUnitMeta, ratioHintText } from '../../lib/rewardUnits'
 import type { Offer, ResolveResult } from '../../types/paymentOffers'
 import type { TypeFilterValue } from './TypeFilter'
+import type { ExcludeFilterValue } from './ExcludeFilter'
 
 interface ResultListProps {
   offers: Offer[]
   amount: number
   typeFilter: TypeFilterValue
+  excludeFilter: ExcludeFilterValue
   selectedCardIds: Set<string>
   query: string
   onQueryChange: (next: string) => void
@@ -41,6 +43,7 @@ export function ResultList({
   offers,
   amount,
   typeFilter,
+  excludeFilter,
   selectedCardIds,
   query,
   onQueryChange,
@@ -49,8 +52,20 @@ export function ResultList({
 
   const filtered = useMemo(() => {
     const byCard = filterOffersByCards(offers, selectedCardIds)
-    return byCard.filter((o) => o.tags.some((t) => typeFilter[t]))
-  }, [offers, selectedCardIds, typeFilter])
+    return byCard.filter((o) => {
+      if (!o.tags.some((t) => typeFilter[t])) return false
+      if (excludeFilter.newCustomer && o.eligibility_restrictions.includes('new_customer'))
+        return false
+      if (
+        excludeFilter.specialMember &&
+        o.eligibility_restrictions.includes('special_member')
+      )
+        return false
+      return true
+    })
+  }, [offers, selectedCardIds, typeFilter, excludeFilter])
+
+  const anyExclude = excludeFilter.newCustomer || excludeFilter.specialMember
 
   const searched = useMemo(() => {
     const q = query.trim().toLowerCase()
@@ -170,7 +185,9 @@ export function ResultList({
           <p className="text-sm font-medium text-gray-700">
             {query
               ? '查無符合方案，試試其他關鍵字'
-              : '目前沒有符合條件的方案，試著放寬類型或卡別篩選'}
+              : anyExclude
+                ? '目前沒有符合條件的方案，試著放寬類型、卡別或排除條件'
+                : '目前沒有符合條件的方案，試著放寬類型或卡別篩選'}
           </p>
         </div>
       ) : (

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -10,14 +10,14 @@
 
 舊架構（`../_legacy/`）把 paytax 名單、卡別清冊、活動表、Tier 規則拆成 8 個 JSON 加 8-phase 校對流程，維護成本高。v2 改以**銀行為主軸**、單一 JSON 承載活動；收集期曾用 `verification` 區分覆核進度，**v2.5 起已移除**，複核與變更紀錄改由 git commit 歷史追蹤。
 
-## Schema（v2.7）
+## Schema（v2.8）
 
 每家銀行可有**多個 campaigns**（不同活動、不同卡別、不同 URL）。每個 campaign 自帶 source URL、適用卡別，內含可選的 `rebate` 與 `installment` 子物件。
 
 ```jsonc
 {
   "tax_year": "114",
-  "schema_version": "v2.7",
+  "schema_version": "v2.8",
   "banks": [
     {
       "bank_code": "005",                       // 三位數金融機構代號
@@ -33,6 +33,9 @@
           "eligible_card_types": ["credit", "debit"], // 適用卡別類型；["credit"] | ["debit"] | ["credit","debit"] | []
           "eligible_card_ids": [                // 明確指定的 card_id 陣列（對應 card_catalog_114.json）；全卡別填 []
             "bank005_jcb_premium"
+          ],
+          "eligibility_restrictions": [         // 身分限制；缺省／空陣列 = 無限制
+            "special_member"                    // "new_customer" | "special_member"
           ],
           "channel": ["台灣 Pay"],              // 繳費管道列表（互斥入口，同一官方管道只列一項）；無限制則 null
           "registration_status": "open",        // "open" | "full" | null；僅 requires_registration=true 時填；缺省視同 null
@@ -77,6 +80,11 @@
 **欄位缺省規則**：`tiers`、`registration_status` 是選填欄位，缺省或未出現時前端視同 `null`。只在有意義時加入，不需要補到每一筆。
 
 **v2.7 欄位移除**：相較 v2.6 刪去 `rebate.{summary,rate_or_amount,tiers,cap}`、`installment.{terms,fee_note}`、`bank.notes`；`amount_tiers` 改為 `kind: "rate" | "fixed"` 的 discriminated union。前端僅顯示 `installment.summary`；若 `installment` 為 `null`，則不顯示分期摘要。
+
+**v2.8 新增**：campaign 加 optional `eligibility_restrictions: ("new_customer" | "special_member")[]`，描述身分門檻，前端「排除活動」 toggle 用。缺省或空陣列＝無限制。
+
+- `new_customer`：限該行 onboarding 新戶（首次申辦數位帳戶／信用卡新戶）。**不**含「分期新戶」這類純行為門檻（任何卡友只要過去未辦分期都符合）。
+- `special_member`：限該行特殊客群——私銀／私人銀行、財管／理財會員（含華南領航、富邦穩富恆富智富、永豐尊榮、台新私銀／財管、中信財管鼎鑽、聯邦財管桂冠、星展新晉豐盛／私人客戶 等）、VIP 星等、亞資客戶。**不**含「非私銀／財管會員」這類反向定義的普通客群，也**不**含「富邦存戶」這類存款戶限定但非會員階級的活動。
 
 **列表文案規則**：`title` 是前端列表掃描用短標籤，預期由卡別／客群／管道加優惠類型組成；銀行名稱、綜所稅、繳稅等頁面上下文通常不重複寫入。`installment.summary` 是一行摘要，優先放主要門檻、期數與上限；登錄、管道限制、互斥、入帳與資格細節放 `period`、`channel`、`requires_registration` 或 `campaign.notes`。摘要目標 35–55 字，階梯式優惠可較長但不應遺失門檻。
 

--- a/src/data/tax_payment_rewards_114.json
+++ b/src/data/tax_payment_rewards_114.json
@@ -1,6 +1,6 @@
 {
   "tax_year": "114",
-  "schema_version": "v2.7",
+  "schema_version": "v2.8",
   "reward_units": {
     "元": { "ntd_per_unit": 1, "kind": "face_value" },
     "元刷卡金": { "ntd_per_unit": 1, "kind": "face_value" },
@@ -312,6 +312,7 @@
       "campaigns": [
         {
           "campaign_id": "rebate_finance",
+          "eligibility_restrictions": ["special_member"],
           "title": "理財客戶｜現金回饋",
           "source_url": "https://card.firstbank.com.tw/sites/card/zh_TW/1565707087044",
           "source_id": "tp_firstbank_twpay_tax_promo",
@@ -468,6 +469,7 @@
       "campaigns": [
         {
           "campaign_id": "vip_rui",
+          "eligibility_restrictions": ["special_member"],
           "title": "睿享家｜刷卡金回饋",
           "source_url": "https://www.hncb.com.tw/wps/portal/HNCB/card/event/TAXCARD",
           "source_id": "tp_hncb_card_event_taxcard",
@@ -499,6 +501,7 @@
         },
         {
           "campaign_id": "vip_du",
+          "eligibility_restrictions": ["special_member"],
           "title": "獨享家｜刷卡金回饋",
           "source_url": "https://www.hncb.com.tw/wps/portal/HNCB/card/event/TAXCARD",
           "source_id": "tp_hncb_card_event_taxcard",
@@ -530,6 +533,7 @@
         },
         {
           "campaign_id": "vip_li",
+          "eligibility_restrictions": ["special_member"],
           "title": "理享家｜刷卡金回饋",
           "source_url": "https://www.hncb.com.tw/wps/portal/HNCB/card/event/TAXCARD",
           "source_id": "tp_hncb_card_event_taxcard",
@@ -561,6 +565,7 @@
         },
         {
           "campaign_id": "vip_meng",
+          "eligibility_restrictions": ["special_member"],
           "title": "夢享家｜刷卡金回饋",
           "source_url": "https://www.hncb.com.tw/wps/portal/HNCB/card/event/TAXCARD",
           "source_id": "tp_hncb_card_event_taxcard",
@@ -761,6 +766,7 @@
         },
         {
           "campaign_id": "wealth_steady",
+          "eligibility_restrictions": ["special_member"],
           "title": "穩富會員｜刷卡金回饋",
           "source_url": "https://cardpromote.taipeifubon.com.tw/promotion/Detail?sn=E000087",
           "source_id": "tp_fubon_cc_2026_ito",
@@ -795,6 +801,7 @@
         },
         {
           "campaign_id": "wealth_premier",
+          "eligibility_restrictions": ["special_member"],
           "title": "恆富／智富｜刷卡金回饋",
           "source_url": "https://cardpromote.taipeifubon.com.tw/promotion/Detail?sn=E000087",
           "source_id": "tp_fubon_cc_2026_ito",
@@ -1143,6 +1150,7 @@
       "campaigns": [
         {
           "campaign_id": "priority_installment",
+          "eligibility_restrictions": ["special_member"],
           "title": "優先理財｜0 利率分期",
           "source_url": "https://www.sc.com/tw/promotions/credit-cards-income-tax/",
           "source_id": "tp_bank_052_tax_114_pending",
@@ -1307,6 +1315,7 @@
         },
         {
           "campaign_id": "newnewbank_tax_rebate",
+          "eligibility_restrictions": ["new_customer"],
           "title": "NewNewBank 新戶｜0.3% 回饋",
           "source_url": "https://activity.ubot.com.tw/aws_act/2025/2025incometax/index.htm",
           "source_id": null,
@@ -1359,6 +1368,7 @@
         },
         {
           "campaign_id": "wealth_mgmt_tax_rebate",
+          "eligibility_restrictions": ["special_member"],
           "title": "財富管理｜0.2% 刷卡金",
           "source_url": "https://activity.ubot.com.tw/aws_act/2025/2025incometax/index.htm",
           "source_id": null,
@@ -1394,6 +1404,7 @@
       "campaigns": [
         {
           "campaign_id": "vip_top_tier",
+          "eligibility_restrictions": ["special_member"],
           "title": "VIP 7-8 星｜0.35% 回饋",
           "source_url": "https://ecard.feib.com.tw/Activity/2026Tax/index.do",
           "source_id": null,
@@ -1423,6 +1434,7 @@
         },
         {
           "campaign_id": "vip_mid_tier",
+          "eligibility_restrictions": ["special_member"],
           "title": "VIP 5-6 星｜0.35% 回饋",
           "source_url": "https://ecard.feib.com.tw/Activity/2026Tax/index.do",
           "source_id": null,
@@ -1594,6 +1606,7 @@
       "campaigns": [
         {
           "campaign_id": "private_bank_asia",
+          "eligibility_restrictions": ["special_member"],
           "title": "私銀／亞資｜0.68% 回饋",
           "source_url": "https://bank.sinopac.com/sinopacBT/personal/credit-card/discount/245305381.html",
           "source_url_alt": "https://bank.sinopac.com/sinopacBT/about/news-center/news/content/2026042401.html",
@@ -1761,6 +1774,7 @@
         },
         {
           "campaign_id": "vip_yongchuan",
+          "eligibility_restrictions": ["special_member"],
           "title": "尊榮永傳會員｜0.38% 回饋",
           "source_url": "https://bank.sinopac.com/sinopacBT/personal/credit-card/discount/245305381.html",
           "source_id": null,
@@ -1795,6 +1809,7 @@
         },
         {
           "campaign_id": "vip_yongfu",
+          "eligibility_restrictions": ["special_member"],
           "title": "尊榮永富會員｜0.25% 回饋",
           "source_url": "https://bank.sinopac.com/sinopacBT/personal/credit-card/discount/245305381.html",
           "source_id": null,
@@ -1829,6 +1844,7 @@
         },
         {
           "campaign_id": "vip_yongju",
+          "eligibility_restrictions": ["special_member"],
           "title": "尊榮永聚會員｜0.15% 回饋",
           "source_url": "https://bank.sinopac.com/sinopacBT/personal/credit-card/discount/245305381.html",
           "source_id": null,
@@ -1979,6 +1995,7 @@
       "campaigns": [
         {
           "campaign_id": "private_bank_rebate",
+          "eligibility_restrictions": ["special_member"],
           "title": "私銀／極致主戶｜e point",
           "source_url": "https://event.esunbank.com.tw/credit/tax/index.html",
           "source_id": null,
@@ -2013,6 +2030,7 @@
         },
         {
           "campaign_id": "wealth_member_rebate_installment",
+          "eligibility_restrictions": ["special_member"],
           "title": "理財會員｜e point 回饋",
           "source_url": "https://event.esunbank.com.tw/credit/tax/index.html",
           "source_id": null,
@@ -2314,6 +2332,7 @@
       "campaigns": [
         {
           "campaign_id": "wealth_newcomer",
+          "eligibility_restrictions": ["special_member"],
           "title": "新晉豐盛理財｜刷卡金",
           "source_url": "https://www.dbs.com.tw/personal-zh/cards/offers/2026tax/index.html",
           "source_id": null,
@@ -2343,6 +2362,7 @@
         },
         {
           "campaign_id": "private_client",
+          "eligibility_restrictions": ["special_member"],
           "title": "私人客戶｜刷卡金",
           "source_url": "https://www.dbs.com.tw/personal-zh/cards/offers/2026tax/index.html",
           "source_id": null,
@@ -2401,6 +2421,7 @@
       "campaigns": [
         {
           "campaign_id": "wealth_rebate_installment",
+          "eligibility_restrictions": ["special_member"],
           "title": "私銀／財管｜刷卡金回饋",
           "source_url": "https://mkp.taishinbank.com.tw/s/2026/tax/index.html",
           "source_url_alt": "https://www.taishinbank.com.tw/TSB/personal/common/news/TSBankNews-007976/",
@@ -2840,6 +2861,7 @@
         },
         {
           "campaign_id": "dingzuan_general",
+          "eligibility_restrictions": ["special_member"],
           "title": "鼎鑽卡｜一般回饋",
           "source_url": "https://mkt.ctbcbank.com/recent/202606/N2026041500015_01-07/index.html",
           "source_id": null,
@@ -2871,6 +2893,7 @@
         },
         {
           "campaign_id": "dingfuhome",
+          "eligibility_restrictions": ["special_member"],
           "title": "鼎富家以上｜加碼回饋",
           "source_url": "https://mkt.ctbcbank.com/recent/202606/N2026041500015_01-07/index.html",
           "source_id": null,
@@ -2902,6 +2925,7 @@
         },
         {
           "campaign_id": "dingfuhome_high",
+          "eligibility_restrictions": ["special_member"],
           "title": "鼎富家｜滿 5,000 萬",
           "source_url": "https://mkt.ctbcbank.com/recent/202606/N2026041500015_01-07/index.html",
           "source_id": null,
@@ -2991,6 +3015,7 @@
         },
         {
           "campaign_id": "jkopay_new_customer_bonus",
+          "eligibility_restrictions": ["new_customer"],
           "title": "街口支付新戶｜加碼 1%",
           "source_url": "https://www.nextbank.com.tw/announcement/45c1e31fa40000000285cadc56793797/event1125",
           "source_id": null,

--- a/src/data/tax_payment_rewards_114.json
+++ b/src/data/tax_payment_rewards_114.json
@@ -2635,8 +2635,9 @@
           "rebate": {
             "requires_registration": false,
             "period": null,
-            "mode": "rate",
-            "rate": 0.333,
+            "mode": "unit_per_amount",
+            "per_amount": 300,
+            "fixed": 1,
             "fixed_unit": "哩",
             "min": null,
             "cap_nt": null,
@@ -2667,8 +2668,9 @@
           "rebate": {
             "requires_registration": false,
             "period": null,
-            "mode": "rate",
-            "rate": 0.333,
+            "mode": "unit_per_amount",
+            "per_amount": 300,
+            "fixed": 1,
             "fixed_unit": "哩",
             "min": null,
             "cap_nt": null,

--- a/src/lib/paymentOffers.ts
+++ b/src/lib/paymentOffers.ts
@@ -7,6 +7,7 @@ import { toNtd } from './rewardUnits'
 import type {
   AmountTier,
   BankListItem,
+  EligibilityRestriction,
   Offer,
   OfferTag,
   RebateMode,
@@ -40,6 +41,7 @@ interface RawCampaign {
   eligible_cards?: string | null
   eligible_card_types?: string[]
   eligible_card_ids?: string[]
+  eligibility_restrictions?: EligibilityRestriction[]
   channel?: string[] | null
   rebate?: RawRebate | null
   installment?: RawInstallment | null
@@ -121,6 +123,7 @@ function toOffer(bank: RawBank, c: RawCampaign, mode: RebateMode): Offer {
     amount_tiers: r.amount_tiers,
     eligible_card_ids: eligibleCardIds,
     is_card_specific: eligibleCardIds.length > 0,
+    eligibility_restrictions: c.eligibility_restrictions ?? [],
     tags,
     requires_registration: r.requires_registration ?? false,
     period: r.period ?? null,

--- a/src/lib/paymentOffers.ts
+++ b/src/lib/paymentOffers.ts
@@ -20,6 +20,7 @@ interface RawRebate {
   mode?: RebateMode
   rate?: number
   fixed?: number
+  per_amount?: number
   fixed_unit?: string
   min?: number | null
   base_fixed?: number | null
@@ -111,6 +112,7 @@ function toOffer(bank: RawBank, c: RawCampaign, mode: RebateMode): Offer {
     mode,
     rate: r.rate,
     fixed: r.fixed,
+    per_amount: r.per_amount,
     fixed_unit: r.fixed_unit,
     min: r.min ?? null,
     base_fixed: r.base_fixed ?? null,
@@ -150,9 +152,31 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
   }
 
   const thresholdLabel =
-    (o.mode === 'fixed' || o.mode === 'rate') && o.min != null && o.min > 0
+    (o.mode === 'fixed' || o.mode === 'rate' || o.mode === 'unit_per_amount') &&
+    o.min != null &&
+    o.min > 0
       ? `單筆滿 ${fmtNT(o.min)}`
       : null
+
+  if (o.mode === 'unit_per_amount') {
+    const per = o.per_amount ?? 0
+    const step = o.fixed ?? 0
+    const raw = per > 0 ? Math.floor(amount / per) * step : 0
+    const cap = o.cap_nt ?? null
+    const capped = cap != null && raw > cap
+    const value = capped ? cap! : raw
+    const unit = o.fixed_unit ?? '元'
+    return {
+      applicable: true,
+      kind: 'unit_per_amount',
+      value,
+      value_ntd: toNtd(value, unit),
+      unit,
+      capped,
+      cap,
+      threshold_label: thresholdLabel,
+    }
+  }
 
   if (o.mode === 'fixed') {
     const unit = o.fixed_unit ?? '元'

--- a/src/types/paymentOffers.ts
+++ b/src/types/paymentOffers.ts
@@ -5,6 +5,7 @@ export type RebateMode =
   | 'rate'              // 單一回饋率
   | 'rate-tiered'       // 階梯回饋率（依金額）
   | 'fixed'             // 定額（NT$ 或紅利點數等價）
+  | 'unit_per_amount'   // 每 N 元累積 M 單位（floor）
   | 'installment_only'  // 僅分期，不算金額
   | 'fee_only'          // 僅手續費說明
 
@@ -51,7 +52,8 @@ export interface Offer {
 
   mode: RebateMode
   rate?: number                 // mode = 'rate' 必填
-  fixed?: number                // mode = 'fixed' 必填
+  fixed?: number                // mode = 'fixed' / 'unit_per_amount' 必填
+  per_amount?: number           // mode = 'unit_per_amount' 必填：每 N 元
   fixed_unit?: string           // 顯示單位字串（例：「元刷卡金」）
   min?: number | null           // 單筆門檻
   base_min?: number | null      // base_fixed 對應門檻

--- a/src/types/paymentOffers.ts
+++ b/src/types/paymentOffers.ts
@@ -11,6 +11,8 @@ export type RebateMode =
 
 export type OfferTag = 'taiwan_pay' | 'credit_card' | 'debit_card' | 'installment'
 
+export type EligibilityRestriction = 'new_customer' | 'special_member'
+
 export interface CatalogCard {
   card_id: string
   bank_code: string
@@ -64,6 +66,8 @@ export interface Offer {
 
   eligible_card_ids: string[]   // 空陣列 = 全卡別；非空 = 限定 card_id
   is_card_specific: boolean     // 衍生：eligible_card_ids.length > 0
+
+  eligibility_restrictions: EligibilityRestriction[] // 身分限制；空陣列 = 無
 
   tags: OfferTag[]
   requires_registration?: boolean

--- a/tests/paymentOffers.test.ts
+++ b/tests/paymentOffers.test.ts
@@ -157,3 +157,93 @@ describe('deriveTags via loadOffers', () => {
     }
   })
 })
+
+describe('eligibility_restrictions 標籤與排除篩選', () => {
+  function byCampaign(id: string) {
+    return offers.find((o) => o.id.endsWith(`_${id}`))
+  }
+
+  it('loader 預設無標註者為空陣列', () => {
+    const general = byCampaign('rebate_general')
+    expect(general).toBeTruthy()
+    expect(general!.eligibility_restrictions).toEqual([])
+  })
+
+  it('new_customer 標籤覆蓋預期 campaign', () => {
+    const ids = ['newnewbank_tax_rebate', 'jkopay_new_customer_bonus']
+    for (const id of ids) {
+      const o = byCampaign(id)
+      expect(o, `missing campaign ${id}`).toBeTruthy()
+      expect(o!.eligibility_restrictions).toContain('new_customer')
+    }
+  })
+
+  it('special_member 標籤涵蓋華南領航、富邦理財、台新財管等', () => {
+    const ids = [
+      'vip_rui',
+      'vip_meng',
+      'wealth_steady',
+      'wealth_rebate_installment',
+      'private_client',
+      'vip_top_tier',
+    ]
+    for (const id of ids) {
+      const o = byCampaign(id)
+      expect(o, `missing campaign ${id}`).toBeTruthy()
+      expect(o!.eligibility_restrictions).toContain('special_member')
+    }
+  })
+
+  it('「分期新戶」與「非私銀／財管會員」依規約不標', () => {
+    const installmentNewUser = byCampaign('online_installment_new_user')
+    expect(installmentNewUser).toBeTruthy()
+    expect(installmentNewUser!.eligibility_restrictions).toEqual([])
+
+    const taishinGeneral = byCampaign('general_rebate')
+    expect(taishinGeneral).toBeTruthy()
+    expect(taishinGeneral!.eligibility_restrictions).toEqual([])
+  })
+
+  function applyExclude(
+    src: typeof offers,
+    excludeNew: boolean,
+    excludeSpecial: boolean,
+  ) {
+    return src.filter((o) => {
+      if (excludeNew && o.eligibility_restrictions.includes('new_customer')) return false
+      if (excludeSpecial && o.eligibility_restrictions.includes('special_member'))
+        return false
+      return true
+    })
+  }
+
+  it('truth table: 兩 exclude 皆 false → 全集', () => {
+    expect(applyExclude(offers, false, false).length).toBe(offers.length)
+  })
+
+  it('truth table: 僅排除新戶 → 僅 new_customer offer 消失', () => {
+    const removed = offers.filter((o) =>
+      o.eligibility_restrictions.includes('new_customer'),
+    )
+    expect(removed.length).toBeGreaterThan(0)
+    const out = applyExclude(offers, true, false)
+    expect(out.length).toBe(offers.length - removed.length)
+    for (const r of removed) expect(out.find((o) => o.id === r.id)).toBeUndefined()
+  })
+
+  it('truth table: 僅排除特殊會員 → 僅 special_member offer 消失', () => {
+    const removed = offers.filter((o) =>
+      o.eligibility_restrictions.includes('special_member'),
+    )
+    expect(removed.length).toBeGreaterThan(0)
+    const out = applyExclude(offers, false, true)
+    expect(out.length).toBe(offers.length - removed.length)
+  })
+
+  it('truth table: 兩者皆排除 → 並集消失，殘餘皆無限制', () => {
+    const restricted = offers.filter((o) => o.eligibility_restrictions.length > 0)
+    const out = applyExclude(offers, true, true)
+    expect(out.length).toBe(offers.length - restricted.length)
+    for (const o of out) expect(o.eligibility_restrictions).toEqual([])
+  })
+})

--- a/tests/paymentOffers.test.ts
+++ b/tests/paymentOffers.test.ts
@@ -107,6 +107,48 @@ describe('resolveOffer rate-tiered 門檻過濾', () => {
   })
 })
 
+describe('resolveOffer unit_per_amount', () => {
+  const anaOffer = offers.find((o) => o.id === '822_ana_miles_rebate')
+
+  it('ANA campaign 已遷移到 unit_per_amount', () => {
+    expect(anaOffer).toBeTruthy()
+    expect(anaOffer!.mode).toBe('unit_per_amount')
+    expect(anaOffer!.per_amount).toBe(300)
+    expect(anaOffer!.fixed).toBe(1)
+    expect(anaOffer!.fixed_unit).toBe('哩')
+  })
+
+  it('amount = 100,000,000 → 333,333 哩（floor，非 0.333% 近似）', () => {
+    const r = resolveOffer(anaOffer!, 100_000_000)
+    expect(r.value).toBe(333_333)
+    expect(r.unit).toBe('哩')
+    expect(r.value_ntd).toBe(333_333 * 0.5)
+  })
+
+  it('amount = 299 → 0 哩；amount = 600 → 2 哩', () => {
+    expect(resolveOffer(anaOffer!, 299).value).toBe(0)
+    expect(resolveOffer(anaOffer!, 600).value).toBe(2)
+  })
+
+  it('合成 cap_nt 觸發 capped', () => {
+    const capped = { ...anaOffer!, cap_nt: 5 }
+    const r = resolveOffer(capped, 100_000)
+    expect(r.value).toBe(5)
+    expect(r.capped).toBe(true)
+    expect(r.cap).toBe(5)
+  })
+
+  it('資料完整性：所有 unit_per_amount campaign 都有 per_amount/fixed/fixed_unit', () => {
+    const all = offers.filter((o) => o.mode === 'unit_per_amount')
+    expect(all.length).toBeGreaterThan(0)
+    for (const o of all) {
+      expect(o.per_amount && o.per_amount > 0).toBeTruthy()
+      expect(o.fixed && o.fixed > 0).toBeTruthy()
+      expect(o.fixed_unit).toBeTruthy()
+    }
+  })
+})
+
 describe('deriveTags via loadOffers', () => {
   it('每個 offer tags 是 4 種已知值的子集', () => {
     const allowed = new Set(['taiwan_pay', 'credit_card', 'debit_card', 'installment'])

--- a/tests/resultList.test.tsx
+++ b/tests/resultList.test.tsx
@@ -3,6 +3,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ResultList } from '../src/components/payment/ResultList'
 import type { TypeFilterValue } from '../src/components/payment/TypeFilter'
+import type { ExcludeFilterValue } from '../src/components/payment/ExcludeFilter'
 import type { Offer } from '../src/types/paymentOffers'
 
 let container: HTMLDivElement
@@ -56,6 +57,7 @@ function makeOffer(overrides: Partial<Offer>): Offer {
     amount_tiers: overrides.amount_tiers,
     eligible_card_ids: overrides.eligible_card_ids ?? [],
     is_card_specific: overrides.is_card_specific ?? false,
+    eligibility_restrictions: overrides.eligibility_restrictions ?? [],
     tags: overrides.tags ?? ['credit_card'],
     requires_registration: overrides.requires_registration ?? false,
     period: overrides.period ?? null,
@@ -65,7 +67,17 @@ function makeOffer(overrides: Partial<Offer>): Offer {
   }
 }
 
-function renderResultList({ offers, amount = 500, query = '' }: { offers: Offer[]; amount?: number; query?: string }) {
+function renderResultList({
+  offers,
+  amount = 500,
+  query = '',
+  excludeFilter = { newCustomer: false, specialMember: false },
+}: {
+  offers: Offer[]
+  amount?: number
+  query?: string
+  excludeFilter?: ExcludeFilterValue
+}) {
   const nextRoot = createRoot(container)
   root = nextRoot
   act(() => {
@@ -74,6 +86,7 @@ function renderResultList({ offers, amount = 500, query = '' }: { offers: Offer[
         offers,
         amount,
         typeFilter: ALL_TYPES_ON,
+        excludeFilter,
         selectedCardIds: new Set<string>(),
         query,
         onQueryChange: () => {},
@@ -194,5 +207,92 @@ describe('ResultList applicable filtering', () => {
     renderResultList({ offers, amount: 500 })
 
     expect(getFirstCapValueText()).toBe('每戶回饋上限 20,000 元')
+  })
+})
+
+describe('ResultList exclude filter', () => {
+  const sampleOffers = (): Offer[] => [
+    makeOffer({
+      id: 'plain',
+      campaign_title: '一般活動',
+      min: 100,
+    }),
+    makeOffer({
+      id: 'newbie',
+      campaign_title: '新戶限定活動',
+      min: 100,
+      eligibility_restrictions: ['new_customer'],
+    }),
+    makeOffer({
+      id: 'vip',
+      campaign_title: '理財會員活動',
+      min: 100,
+      eligibility_restrictions: ['special_member'],
+    }),
+  ]
+
+  it('預設不勾排除 → 三筆 offer 全顯示', () => {
+    renderResultList({ offers: sampleOffers(), amount: 500 })
+    expect(container.textContent).toContain('一般活動')
+    expect(container.textContent).toContain('新戶限定活動')
+    expect(container.textContent).toContain('理財會員活動')
+    expect(container.textContent).toContain('共 3 個方案')
+  })
+
+  it('勾排除新戶 → 僅隱藏 new_customer offer', () => {
+    renderResultList({
+      offers: sampleOffers(),
+      amount: 500,
+      excludeFilter: { newCustomer: true, specialMember: false },
+    })
+    expect(container.textContent).toContain('一般活動')
+    expect(container.textContent).not.toContain('新戶限定活動')
+    expect(container.textContent).toContain('理財會員活動')
+    expect(container.textContent).toContain('共 2 個方案')
+  })
+
+  it('勾排除特殊會員 → 僅隱藏 special_member offer', () => {
+    renderResultList({
+      offers: sampleOffers(),
+      amount: 500,
+      excludeFilter: { newCustomer: false, specialMember: true },
+    })
+    expect(container.textContent).toContain('一般活動')
+    expect(container.textContent).toContain('新戶限定活動')
+    expect(container.textContent).not.toContain('理財會員活動')
+    expect(container.textContent).toContain('共 2 個方案')
+  })
+
+  it('兩者皆勾且全部被排 → 顯示帶「排除條件」的 empty state', () => {
+    const restrictedOnly: Offer[] = [
+      makeOffer({
+        id: 'newbie',
+        campaign_title: '新戶限定活動',
+        min: 100,
+        eligibility_restrictions: ['new_customer'],
+      }),
+      makeOffer({
+        id: 'vip',
+        campaign_title: '理財會員活動',
+        min: 100,
+        eligibility_restrictions: ['special_member'],
+      }),
+    ]
+    renderResultList({
+      offers: restrictedOnly,
+      amount: 500,
+      excludeFilter: { newCustomer: true, specialMember: true },
+    })
+    expect(container.textContent).toContain('目前沒有符合條件的方案，試著放寬類型、卡別或排除條件')
+    expect(container.textContent).not.toContain('新戶限定活動')
+    expect(container.textContent).not.toContain('理財會員活動')
+  })
+
+  it('未勾排除時，empty state 維持原文案', () => {
+    renderResultList({
+      offers: [],
+      amount: 500,
+    })
+    expect(container.textContent).toContain('目前沒有符合條件的方案，試著放寬類型或卡別篩選')
   })
 })


### PR DESCRIPTION
## Summary

Adds two opt-in exclusion checkboxes to the payment-rewards filter panel,
placed below the existing "回饋類型" toggles:

- **排除新戶身分** — hides campaigns restricted to bank-onboarding new customers
- **排除銀行特殊會員** — hides campaigns restricted to wealth-management /
  VIP-tier members

Both default to **unchecked** (show everything), preserving current behaviour.
State is persisted in the existing localStorage key (`tax.payment.rewards.v2`)
with a backward-compatible optional field.

## Data changes (schema v2.7 → v2.8)

Added `eligibility_restrictions: ("new_customer" | "special_member")[]` to 25
campaigns across 13 banks. Tagging rules:

| Value | Included | Excluded |
|---|---|---|
| `new_customer` | 聯邦 NewNewBank 新戶, 將來銀行首次開戶新戶 | 永豐「分期新戶」(installment behaviour, not onboarding) |
| `special_member` | 華南領航 4 級, 富邦穩富/恆富/智富, 渣打優先理財, 兆豐 VIP, 北富銀私銀, 永豐尊榮理財, 台新私銀/財管, 中信財管鼎鑽, 聯邦財管桂冠, 星展新晉豐盛/私人客戶, 一銀理財 | 台新「非私銀/財管會員」(general public, inverse definition), 富邦存戶 (deposit-holder, not a member tier) |

See `src/data/README.md` for the full taxonomy.

## Files changed

| File | Change |
|---|---|
| `src/types/paymentOffers.ts` | `EligibilityRestriction` union; `Offer.eligibility_restrictions` field |
| `src/lib/paymentOffers.ts` | `RawCampaign` optional field; `toOffer` defaults to `[]` |
| `src/data/tax_payment_rewards_114.json` | 25 campaigns tagged |
| `src/data/README.md` | v2.8 field docs + tagging taxonomy |
| `src/components/payment/ExcludeFilter.tsx` | New component |
| `src/components/PaymentRewardsPage.tsx` | State, localStorage, render |
| `src/components/payment/ResultList.tsx` | Filter predicate + empty-state copy |
| `tests/paymentOffers.test.ts` | 9 new unit tests (truth table + label coverage) |
| `tests/resultList.test.tsx` | 5 new UI-level tests (exclude branches + empty-state copy) |

## Testing

- `pnpm test` — 393/393 pass
- `pnpm lint` — clean