### PR TITLE
feat: launch payment rewards page with card-based filtering and data corrections

### DIFF
--- a/src/components/PaymentRewardsPage.tsx
+++ b/src/components/PaymentRewardsPage.tsx
@@ -4,6 +4,8 @@ import { PageHeading } from './ui/PageHeading'
 import { AmountInput } from './payment/AmountInput'
 import { TypeFilter } from './payment/TypeFilter'
 import type { TypeFilterValue } from './payment/TypeFilter'
+import { ExcludeFilter } from './payment/ExcludeFilter'
+import type { ExcludeFilterValue } from './payment/ExcludeFilter'
 import { CardPicker } from './payment/CardPicker'
 import { ResultList } from './payment/ResultList'
 import { loadOffers } from '../lib/paymentOffers'
@@ -13,6 +15,7 @@ const LS_KEY = 'tax.payment.rewards.v2'
 interface SavedState {
   amount?: number
   typeFilter?: TypeFilterValue
+  excludeFilter?: ExcludeFilterValue
   selectedCardIds?: string[]
 }
 
@@ -31,6 +34,11 @@ const DEFAULT_TYPE_FILTER: TypeFilterValue = {
   credit_card: true,
   debit_card: true,
   installment: true,
+}
+
+const DEFAULT_EXCLUDE_FILTER: ExcludeFilterValue = {
+  newCustomer: false,
+  specialMember: false,
 }
 
 function AmountEmptyState() {
@@ -95,6 +103,10 @@ export function PaymentRewardsPage() {
     ...DEFAULT_TYPE_FILTER,
     ...(saved?.typeFilter ?? {}),
   }))
+  const [excludeFilter, setExcludeFilter] = useState<ExcludeFilterValue>(() => ({
+    ...DEFAULT_EXCLUDE_FILTER,
+    ...(saved?.excludeFilter ?? {}),
+  }))
   const [selectedCardIds, setSelectedCardIds] = useState<Set<string>>(
     () => new Set(saved?.selectedCardIds ?? []),
   )
@@ -105,13 +117,14 @@ export function PaymentRewardsPage() {
       const payload: SavedState = {
         amount,
         typeFilter,
+        excludeFilter,
         selectedCardIds: Array.from(selectedCardIds),
       }
       localStorage.setItem(LS_KEY, JSON.stringify(payload))
     } catch {
       // localStorage unavailable
     }
-  }, [amount, typeFilter, selectedCardIds])
+  }, [amount, typeFilter, excludeFilter, selectedCardIds])
 
   const anyType = Object.values(typeFilter).some(Boolean)
 
@@ -131,7 +144,10 @@ export function PaymentRewardsPage() {
         <>
           <section className="bg-white rounded-xl border border-gray-200 p-5 mb-6">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-5 items-start">
-              <TypeFilter value={typeFilter} onChange={setTypeFilter} />
+              <div className="flex flex-col gap-3">
+                <TypeFilter value={typeFilter} onChange={setTypeFilter} />
+                <ExcludeFilter value={excludeFilter} onChange={setExcludeFilter} />
+              </div>
               <CardPicker value={selectedCardIds} onChange={setSelectedCardIds} />
             </div>
           </section>
@@ -141,6 +157,7 @@ export function PaymentRewardsPage() {
               offers={offers}
               amount={amount}
               typeFilter={typeFilter}
+              excludeFilter={excludeFilter}
               selectedCardIds={selectedCardIds}
               query={query}
               onQueryChange={setQuery}

--- a/src/components/payment/ExcludeFilter.tsx
+++ b/src/components/payment/ExcludeFilter.tsx
@@ -1,0 +1,55 @@
+import { Check } from 'lucide-react'
+
+export interface ExcludeFilterValue {
+  newCustomer: boolean
+  specialMember: boolean
+}
+
+const ITEMS: Array<{ key: keyof ExcludeFilterValue; label: string }> = [
+  { key: 'newCustomer', label: '排除新戶身分' },
+  { key: 'specialMember', label: '排除銀行特殊會員' },
+]
+
+interface ExcludeFilterProps {
+  value: ExcludeFilterValue
+  onChange: (next: ExcludeFilterValue) => void
+}
+
+export function ExcludeFilter({ value, onChange }: ExcludeFilterProps) {
+  function toggle(k: keyof ExcludeFilterValue) {
+    onChange({ ...value, [k]: !value[k] })
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {ITEMS.map(({ key, label }) => {
+        const on = value[key]
+        return (
+          <button
+            key={key}
+            type="button"
+            role="switch"
+            aria-checked={on}
+            onClick={() => toggle(key)}
+            className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-2.5 text-base transition-colors ${
+              on
+                ? 'bg-blue-600 text-white border-blue-600 hover:bg-blue-700'
+                : 'bg-white text-gray-500 border-gray-200 hover:text-gray-900'
+            }`}
+          >
+            <span
+              className={`w-3.5 h-3.5 rounded border flex items-center justify-center transition-colors ${
+                on
+                  ? 'bg-white border-white text-blue-600'
+                  : 'bg-white border-gray-300 text-transparent'
+              }`}
+            >
+              <Check size={9} />
+            </span>
+            <span>{label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/payment/OfferRow.tsx
+++ b/src/components/payment/OfferRow.tsx
@@ -36,7 +36,8 @@ export function OfferRow({ offer, rank, amount, isTop }: OfferRowProps) {
   const isInstallmentOnly = r.kind === 'installment_only'
   const isFeeOnly = r.kind === 'fee_only'
   const isFixed = r.kind === 'fixed'
-  const isRebate = r.kind === 'rate' || r.kind === 'rate-tiered'
+  const isRebate =
+    r.kind === 'rate' || r.kind === 'rate-tiered' || r.kind === 'unit_per_amount'
   const highlightHeadline = isTop && r.value != null && r.value > 0
 
   const rankCls = isTop
@@ -89,6 +90,13 @@ export function OfferRow({ offer, rank, amount, isTop }: OfferRowProps) {
   const rateLabel = (() => {
     if (isInstallmentOnly || isFeeOnly) return '—'
     if (offer.mode === 'fixed') return '固定金額'
+    if (offer.mode === 'unit_per_amount') {
+      const per = offer.per_amount
+      const step = offer.fixed
+      const unit = offer.fixed_unit
+      if (per && step && unit) return `每 ${per.toLocaleString('zh-TW')} 元 ${step} ${unit}`
+      return offer.cap_label ?? '—'
+    }
     return fmtPct(r.rate ?? offer.rate ?? null)
   })()
 

--- a/src/components/payment/OfferRow.tsx
+++ b/src/components/payment/OfferRow.tsx
@@ -1,6 +1,7 @@
 import { ExternalLink, Info } from 'lucide-react'
 import { Card } from '../ui/Card'
 import { fmtNT, fmtPct, resolveOffer } from '../../lib/paymentOffers'
+import { getUnitMeta, ratioHintText } from '../../lib/rewardUnits'
 import type { Offer, OfferTag } from '../../types/paymentOffers'
 
 interface OfferRowProps {
@@ -46,6 +47,12 @@ export function OfferRow({ offer, rank, amount, isTop }: OfferRowProps) {
 
   // Headline number
   const isNTUnit = !r.unit || r.unit === '元'
+  const unitMeta = getUnitMeta(r.unit)
+  const showNtdHint =
+    unitMeta.kind === 'cash_equivalent' &&
+    r.value_ntd != null &&
+    r.value_ntd > 0 &&
+    !isNTUnit
   const formatValue = (v: number) =>
     isNTUnit ? fmtNT(v) : Math.round(v).toLocaleString('zh-TW')
   let headline: React.ReactNode
@@ -133,6 +140,15 @@ export function OfferRow({ offer, rank, amount, isTop }: OfferRowProps) {
               </p>
               <div className="min-w-0">
                 {headline}
+                {showNtdHint && (
+                  <p className="text-base text-gray-500 mt-0.5 tabular-nums">
+                    ≈ {fmtNT(r.value_ntd!)}
+                    {(() => {
+                      const hint = ratioHintText(r.unit)
+                      return hint ? <span className="ml-1 text-gray-400">（{hint}）</span> : null
+                    })()}
+                  </p>
+                )}
                 {r.capped && (
                   <p className="text-base text-amber-700 mt-1">
                     已達上限 {r.cap != null ? formatValue(r.cap) : '—'}

--- a/src/components/payment/ResultList.tsx
+++ b/src/components/payment/ResultList.tsx
@@ -10,11 +10,13 @@ import {
 import { getUnitMeta, ratioHintText } from '../../lib/rewardUnits'
 import type { Offer, ResolveResult } from '../../types/paymentOffers'
 import type { TypeFilterValue } from './TypeFilter'
+import type { ExcludeFilterValue } from './ExcludeFilter'
 
 interface ResultListProps {
   offers: Offer[]
   amount: number
   typeFilter: TypeFilterValue
+  excludeFilter: ExcludeFilterValue
   selectedCardIds: Set<string>
   query: string
   onQueryChange: (next: string) => void
@@ -41,6 +43,7 @@ export function ResultList({
   offers,
   amount,
   typeFilter,
+  excludeFilter,
   selectedCardIds,
   query,
   onQueryChange,
@@ -49,8 +52,20 @@ export function ResultList({
 
   const filtered = useMemo(() => {
     const byCard = filterOffersByCards(offers, selectedCardIds)
-    return byCard.filter((o) => o.tags.some((t) => typeFilter[t]))
-  }, [offers, selectedCardIds, typeFilter])
+    return byCard.filter((o) => {
+      if (!o.tags.some((t) => typeFilter[t])) return false
+      if (excludeFilter.newCustomer && o.eligibility_restrictions.includes('new_customer'))
+        return false
+      if (
+        excludeFilter.specialMember &&
+        o.eligibility_restrictions.includes('special_member')
+      )
+        return false
+      return true
+    })
+  }, [offers, selectedCardIds, typeFilter, excludeFilter])
+
+  const anyExclude = excludeFilter.newCustomer || excludeFilter.specialMember
 
   const searched = useMemo(() => {
     const q = query.trim().toLowerCase()
@@ -170,7 +185,9 @@ export function ResultList({
           <p className="text-sm font-medium text-gray-700">
             {query
               ? '查無符合方案，試試其他關鍵字'
-              : '目前沒有符合條件的方案，試著放寬類型或卡別篩選'}
+              : anyExclude
+                ? '目前沒有符合條件的方案，試著放寬類型、卡別或排除條件'
+                : '目前沒有符合條件的方案，試著放寬類型或卡別篩選'}
           </p>
         </div>
       ) : (

--- a/src/components/payment/ResultList.tsx
+++ b/src/components/payment/ResultList.tsx
@@ -7,6 +7,7 @@ import {
   fmtPct,
   resolveOffer,
 } from '../../lib/paymentOffers'
+import { getUnitMeta, ratioHintText } from '../../lib/rewardUnits'
 import type { Offer, ResolveResult } from '../../types/paymentOffers'
 import type { TypeFilterValue } from './TypeFilter'
 
@@ -26,8 +27,8 @@ interface RankedRow {
 
 function sortRanked(rows: RankedRow[]): RankedRow[] {
   return [...rows].sort((a, b) => {
-    const va = a.r.value ?? -1
-    const vb = b.r.value ?? -1
+    const va = a.r.value_ntd ?? -Infinity
+    const vb = b.r.value_ntd ?? -Infinity
     if (va !== vb) return vb - va
     const ba = a.o.bank
     const bb = b.o.bank
@@ -70,8 +71,8 @@ export function ResultList({
   const top = useMemo(() => {
     const pool = filtered
       .map((o) => ({ o, r: resolveOffer(o, amount) }))
-      .filter((x) => x.r.applicable && x.r.value != null && x.r.value > 0)
-      .sort((a, b) => (b.r.value ?? 0) - (a.r.value ?? 0))
+      .filter((x) => x.r.applicable && x.r.value_ntd != null && x.r.value_ntd > 0)
+      .sort((a, b) => (b.r.value_ntd ?? 0) - (a.r.value_ntd ?? 0))
     return pool[0]
   }, [filtered, amount])
 
@@ -100,6 +101,24 @@ export function ResultList({
                   return `${Math.round(top.r.value ?? 0).toLocaleString('zh-TW')} ${top.r.unit}`
                 })()}
               </span>
+              {(() => {
+                const isNTUnit = !top.r.unit || top.r.unit === '元'
+                const meta = getUnitMeta(top.r.unit)
+                if (
+                  isNTUnit ||
+                  meta.kind !== 'cash_equivalent' ||
+                  top.r.value_ntd == null ||
+                  top.r.value_ntd <= 0
+                )
+                  return null
+                const hint = ratioHintText(top.r.unit)
+                return (
+                  <span className="text-gray-500 ml-1 tabular-nums">
+                    （約 {fmtNT(top.r.value_ntd)}
+                    {hint ? `，${hint}` : ''}）
+                  </span>
+                )
+              })()}
               {top.r.rate != null && top.r.rate > 0 ? (
                 <span className="text-gray-500">
                   （回饋率 {fmtPct(top.r.rate)}

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -10,14 +10,14 @@
 
 舊架構（`../_legacy/`）把 paytax 名單、卡別清冊、活動表、Tier 規則拆成 8 個 JSON 加 8-phase 校對流程，維護成本高。v2 改以**銀行為主軸**、單一 JSON 承載活動；收集期曾用 `verification` 區分覆核進度，**v2.5 起已移除**，複核與變更紀錄改由 git commit 歷史追蹤。
 
-## Schema（v2.7）
+## Schema（v2.8）
 
 每家銀行可有**多個 campaigns**（不同活動、不同卡別、不同 URL）。每個 campaign 自帶 source URL、適用卡別，內含可選的 `rebate` 與 `installment` 子物件。
 
 ```jsonc
 {
   "tax_year": "114",
-  "schema_version": "v2.7",
+  "schema_version": "v2.8",
   "banks": [
     {
       "bank_code": "005",                       // 三位數金融機構代號
@@ -33,6 +33,9 @@
           "eligible_card_types": ["credit", "debit"], // 適用卡別類型；["credit"] | ["debit"] | ["credit","debit"] | []
           "eligible_card_ids": [                // 明確指定的 card_id 陣列（對應 card_catalog_114.json）；全卡別填 []
             "bank005_jcb_premium"
+          ],
+          "eligibility_restrictions": [         // 身分限制；缺省／空陣列 = 無限制
+            "special_member"                    // "new_customer" | "special_member"
           ],
           "channel": ["台灣 Pay"],              // 繳費管道列表（互斥入口，同一官方管道只列一項）；無限制則 null
           "registration_status": "open",        // "open" | "full" | null；僅 requires_registration=true 時填；缺省視同 null
@@ -77,6 +80,11 @@
 **欄位缺省規則**：`tiers`、`registration_status` 是選填欄位，缺省或未出現時前端視同 `null`。只在有意義時加入，不需要補到每一筆。
 
 **v2.7 欄位移除**：相較 v2.6 刪去 `rebate.{summary,rate_or_amount,tiers,cap}`、`installment.{terms,fee_note}`、`bank.notes`；`amount_tiers` 改為 `kind: "rate" | "fixed"` 的 discriminated union。前端僅顯示 `installment.summary`；若 `installment` 為 `null`，則不顯示分期摘要。
+
+**v2.8 新增**：campaign 加 optional `eligibility_restrictions: ("new_customer" | "special_member")[]`，描述身分門檻，前端「排除活動」 toggle 用。缺省或空陣列＝無限制。
+
+- `new_customer`：限該行 onboarding 新戶（首次申辦數位帳戶／信用卡新戶）。**不**含「分期新戶」這類純行為門檻（任何卡友只要過去未辦分期都符合）。
+- `special_member`：限該行特殊客群——私銀／私人銀行、財管／理財會員（含華南領航、富邦穩富恆富智富、永豐尊榮、台新私銀／財管、中信財管鼎鑽、聯邦財管桂冠、星展新晉豐盛／私人客戶 等）、VIP 星等、亞資客戶。**不**含「非私銀／財管會員」這類反向定義的普通客群，也**不**含「富邦存戶」這類存款戶限定但非會員階級的活動。
 
 **列表文案規則**：`title` 是前端列表掃描用短標籤，預期由卡別／客群／管道加優惠類型組成；銀行名稱、綜所稅、繳稅等頁面上下文通常不重複寫入。`installment.summary` 是一行摘要，優先放主要門檻、期數與上限；登錄、管道限制、互斥、入帳與資格細節放 `period`、`channel`、`requires_registration` 或 `campaign.notes`。摘要目標 35–55 字，階梯式優惠可較長但不應遺失門檻。
 

--- a/src/data/tax_payment_rewards_114.json
+++ b/src/data/tax_payment_rewards_114.json
@@ -1,6 +1,6 @@
 {
   "tax_year": "114",
-  "schema_version": "v2.7",
+  "schema_version": "v2.8",
   "reward_units": {
     "元": { "ntd_per_unit": 1, "kind": "face_value" },
     "元刷卡金": { "ntd_per_unit": 1, "kind": "face_value" },
@@ -312,6 +312,7 @@
       "campaigns": [
         {
           "campaign_id": "rebate_finance",
+          "eligibility_restrictions": ["special_member"],
           "title": "理財客戶｜現金回饋",
           "source_url": "https://card.firstbank.com.tw/sites/card/zh_TW/1565707087044",
           "source_id": "tp_firstbank_twpay_tax_promo",
@@ -468,6 +469,7 @@
       "campaigns": [
         {
           "campaign_id": "vip_rui",
+          "eligibility_restrictions": ["special_member"],
           "title": "睿享家｜刷卡金回饋",
           "source_url": "https://www.hncb.com.tw/wps/portal/HNCB/card/event/TAXCARD",
           "source_id": "tp_hncb_card_event_taxcard",
@@ -499,6 +501,7 @@
         },
         {
           "campaign_id": "vip_du",
+          "eligibility_restrictions": ["special_member"],
           "title": "獨享家｜刷卡金回饋",
           "source_url": "https://www.hncb.com.tw/wps/portal/HNCB/card/event/TAXCARD",
           "source_id": "tp_hncb_card_event_taxcard",
@@ -530,6 +533,7 @@
         },
         {
           "campaign_id": "vip_li",
+          "eligibility_restrictions": ["special_member"],
           "title": "理享家｜刷卡金回饋",
           "source_url": "https://www.hncb.com.tw/wps/portal/HNCB/card/event/TAXCARD",
           "source_id": "tp_hncb_card_event_taxcard",
@@ -561,6 +565,7 @@
         },
         {
           "campaign_id": "vip_meng",
+          "eligibility_restrictions": ["special_member"],
           "title": "夢享家｜刷卡金回饋",
           "source_url": "https://www.hncb.com.tw/wps/portal/HNCB/card/event/TAXCARD",
           "source_id": "tp_hncb_card_event_taxcard",
@@ -761,6 +766,7 @@
         },
         {
           "campaign_id": "wealth_steady",
+          "eligibility_restrictions": ["special_member"],
           "title": "穩富會員｜刷卡金回饋",
           "source_url": "https://cardpromote.taipeifubon.com.tw/promotion/Detail?sn=E000087",
           "source_id": "tp_fubon_cc_2026_ito",
@@ -795,6 +801,7 @@
         },
         {
           "campaign_id": "wealth_premier",
+          "eligibility_restrictions": ["special_member"],
           "title": "恆富／智富｜刷卡金回饋",
           "source_url": "https://cardpromote.taipeifubon.com.tw/promotion/Detail?sn=E000087",
           "source_id": "tp_fubon_cc_2026_ito",
@@ -1143,6 +1150,7 @@
       "campaigns": [
         {
           "campaign_id": "priority_installment",
+          "eligibility_restrictions": ["special_member"],
           "title": "優先理財｜0 利率分期",
           "source_url": "https://www.sc.com/tw/promotions/credit-cards-income-tax/",
           "source_id": "tp_bank_052_tax_114_pending",
@@ -1307,6 +1315,7 @@
         },
         {
           "campaign_id": "newnewbank_tax_rebate",
+          "eligibility_restrictions": ["new_customer"],
           "title": "NewNewBank 新戶｜0.3% 回饋",
           "source_url": "https://activity.ubot.com.tw/aws_act/2025/2025incometax/index.htm",
           "source_id": null,
@@ -1359,6 +1368,7 @@
         },
         {
           "campaign_id": "wealth_mgmt_tax_rebate",
+          "eligibility_restrictions": ["special_member"],
           "title": "財富管理｜0.2% 刷卡金",
           "source_url": "https://activity.ubot.com.tw/aws_act/2025/2025incometax/index.htm",
           "source_id": null,
@@ -1394,6 +1404,7 @@
       "campaigns": [
         {
           "campaign_id": "vip_top_tier",
+          "eligibility_restrictions": ["special_member"],
           "title": "VIP 7-8 星｜0.35% 回饋",
           "source_url": "https://ecard.feib.com.tw/Activity/2026Tax/index.do",
           "source_id": null,
@@ -1423,6 +1434,7 @@
         },
         {
           "campaign_id": "vip_mid_tier",
+          "eligibility_restrictions": ["special_member"],
           "title": "VIP 5-6 星｜0.35% 回饋",
           "source_url": "https://ecard.feib.com.tw/Activity/2026Tax/index.do",
           "source_id": null,
@@ -1594,6 +1606,7 @@
       "campaigns": [
         {
           "campaign_id": "private_bank_asia",
+          "eligibility_restrictions": ["special_member"],
           "title": "私銀／亞資｜0.68% 回饋",
           "source_url": "https://bank.sinopac.com/sinopacBT/personal/credit-card/discount/245305381.html",
           "source_url_alt": "https://bank.sinopac.com/sinopacBT/about/news-center/news/content/2026042401.html",
@@ -1761,6 +1774,7 @@
         },
         {
           "campaign_id": "vip_yongchuan",
+          "eligibility_restrictions": ["special_member"],
           "title": "尊榮永傳會員｜0.38% 回饋",
           "source_url": "https://bank.sinopac.com/sinopacBT/personal/credit-card/discount/245305381.html",
           "source_id": null,
@@ -1795,6 +1809,7 @@
         },
         {
           "campaign_id": "vip_yongfu",
+          "eligibility_restrictions": ["special_member"],
           "title": "尊榮永富會員｜0.25% 回饋",
           "source_url": "https://bank.sinopac.com/sinopacBT/personal/credit-card/discount/245305381.html",
           "source_id": null,
@@ -1829,6 +1844,7 @@
         },
         {
           "campaign_id": "vip_yongju",
+          "eligibility_restrictions": ["special_member"],
           "title": "尊榮永聚會員｜0.15% 回饋",
           "source_url": "https://bank.sinopac.com/sinopacBT/personal/credit-card/discount/245305381.html",
           "source_id": null,
@@ -1979,6 +1995,7 @@
       "campaigns": [
         {
           "campaign_id": "private_bank_rebate",
+          "eligibility_restrictions": ["special_member"],
           "title": "私銀／極致主戶｜e point",
           "source_url": "https://event.esunbank.com.tw/credit/tax/index.html",
           "source_id": null,
@@ -2013,6 +2030,7 @@
         },
         {
           "campaign_id": "wealth_member_rebate_installment",
+          "eligibility_restrictions": ["special_member"],
           "title": "理財會員｜e point 回饋",
           "source_url": "https://event.esunbank.com.tw/credit/tax/index.html",
           "source_id": null,
@@ -2314,6 +2332,7 @@
       "campaigns": [
         {
           "campaign_id": "wealth_newcomer",
+          "eligibility_restrictions": ["special_member"],
           "title": "新晉豐盛理財｜刷卡金",
           "source_url": "https://www.dbs.com.tw/personal-zh/cards/offers/2026tax/index.html",
           "source_id": null,
@@ -2343,6 +2362,7 @@
         },
         {
           "campaign_id": "private_client",
+          "eligibility_restrictions": ["special_member"],
           "title": "私人客戶｜刷卡金",
           "source_url": "https://www.dbs.com.tw/personal-zh/cards/offers/2026tax/index.html",
           "source_id": null,
@@ -2401,6 +2421,7 @@
       "campaigns": [
         {
           "campaign_id": "wealth_rebate_installment",
+          "eligibility_restrictions": ["special_member"],
           "title": "私銀／財管｜刷卡金回饋",
           "source_url": "https://mkp.taishinbank.com.tw/s/2026/tax/index.html",
           "source_url_alt": "https://www.taishinbank.com.tw/TSB/personal/common/news/TSBankNews-007976/",
@@ -2635,8 +2656,9 @@
           "rebate": {
             "requires_registration": false,
             "period": null,
-            "mode": "rate",
-            "rate": 0.333,
+            "mode": "unit_per_amount",
+            "per_amount": 300,
+            "fixed": 1,
             "fixed_unit": "哩",
             "min": null,
             "cap_nt": null,
@@ -2667,8 +2689,9 @@
           "rebate": {
             "requires_registration": false,
             "period": null,
-            "mode": "rate",
-            "rate": 0.333,
+            "mode": "unit_per_amount",
+            "per_amount": 300,
+            "fixed": 1,
             "fixed_unit": "哩",
             "min": null,
             "cap_nt": null,
@@ -2838,6 +2861,7 @@
         },
         {
           "campaign_id": "dingzuan_general",
+          "eligibility_restrictions": ["special_member"],
           "title": "鼎鑽卡｜一般回饋",
           "source_url": "https://mkt.ctbcbank.com/recent/202606/N2026041500015_01-07/index.html",
           "source_id": null,
@@ -2869,6 +2893,7 @@
         },
         {
           "campaign_id": "dingfuhome",
+          "eligibility_restrictions": ["special_member"],
           "title": "鼎富家以上｜加碼回饋",
           "source_url": "https://mkt.ctbcbank.com/recent/202606/N2026041500015_01-07/index.html",
           "source_id": null,
@@ -2900,6 +2925,7 @@
         },
         {
           "campaign_id": "dingfuhome_high",
+          "eligibility_restrictions": ["special_member"],
           "title": "鼎富家｜滿 5,000 萬",
           "source_url": "https://mkt.ctbcbank.com/recent/202606/N2026041500015_01-07/index.html",
           "source_id": null,
@@ -2989,6 +3015,7 @@
         },
         {
           "campaign_id": "jkopay_new_customer_bonus",
+          "eligibility_restrictions": ["new_customer"],
           "title": "街口支付新戶｜加碼 1%",
           "source_url": "https://www.nextbank.com.tw/announcement/45c1e31fa40000000285cadc56793797/event1125",
           "source_id": null,

--- a/src/data/tax_payment_rewards_114.json
+++ b/src/data/tax_payment_rewards_114.json
@@ -1,6 +1,23 @@
 {
   "tax_year": "114",
   "schema_version": "v2.7",
+  "reward_units": {
+    "元": { "ntd_per_unit": 1, "kind": "face_value" },
+    "元刷卡金": { "ntd_per_unit": 1, "kind": "face_value" },
+    "元 SOGO 禮券": { "ntd_per_unit": 1, "kind": "face_value" },
+    "元即享券": { "ntd_per_unit": 1, "kind": "face_value" },
+    "元統一超商抵用券": { "ntd_per_unit": 1, "kind": "face_value" },
+    "元超商電子禮券": { "ntd_per_unit": 1, "kind": "face_value" },
+    "元電子禮券": { "ntd_per_unit": 1, "kind": "face_value" },
+    "點台灣 Pay 紅利": { "ntd_per_unit": 0.1, "kind": "cash_equivalent" },
+    "LINE POINTS": { "ntd_per_unit": 1, "kind": "cash_equivalent" },
+    "OPEN POINTS": { "ntd_per_unit": 1, "kind": "cash_equivalent" },
+    "小樹點": { "ntd_per_unit": 1, "kind": "cash_equivalent" },
+    "街口幣": { "ntd_per_unit": 1, "kind": "cash_equivalent" },
+    "e point": { "ntd_per_unit": 1, "kind": "cash_equivalent" },
+    "和泰 Points": { "ntd_per_unit": 1, "kind": "cash_equivalent" },
+    "哩": { "ntd_per_unit": 0.5, "kind": "cash_equivalent" }
+  },
   "banks": [
     {
       "bank_code": "004",

--- a/src/data/tax_payment_rewards_114.json
+++ b/src/data/tax_payment_rewards_114.json
@@ -2236,14 +2236,14 @@
             "requires_registration": false,
             "period": "2026/5/1~2026/6/4",
             "mode": "rate",
-            "rate": 1,
+            "rate": 0.5,
             "fixed_unit": "元",
             "min": null,
             "cap_nt": 500,
             "cap_label": "玉山 0.5% 上限 500 點；首綁加碼 50 點"
           },
           "installment": null,
-          "notes": "不適用玉山官網繳稅分期優惠。綁卡繳稅成功後無法取消變更。最高約 1% 含首綁加碼（全支付活動）。",
+          "notes": "不適用玉山官網繳稅分期優惠。綁卡繳稅成功後無法取消變更。",
           "tags": [
             "credit_card"
           ]
@@ -2427,7 +2427,7 @@
             "summary": "不限金額享 3／6 期 0 利率；滿 120,000 元享 12 期 0 利率",
             "min_amount": null
           },
-          "notes": "回饋與 0 利率分期可並用，須分別登錄；Richart 萬事達卡、JCB 全卡單筆滿 20 萬可加碼至 0.5%；限信用卡固定額度內；行動支付／超商繳稅不適用",
+          "notes": "回饋與 0 利率分期可並用，須分別登錄；Richart 萬事達卡、JCB 全卡單筆滿 20 萬之加碼 0.1% 另列為獨立方案（campaign_id: richart_jcb_single_tx_bonus）；限信用卡固定額度內；行動支付／超商繳稅不適用",
           "tags": [
             "credit_card",
             "installment"
@@ -2458,7 +2458,40 @@
             "cap_label": "每名持卡人合計上限 2,000 元"
           },
           "installment": null,
-          "notes": "與一般卡友 0 利率分期擇一，同時登錄以分期為準；Richart 萬事達卡、JCB 全卡單筆滿 20 萬可再加碼 0.1%，加碼上限 100,000 元；預計 2026/9/30 前入帳。",
+          "notes": "與一般卡友 0 利率分期擇一，同時登錄以分期為準；Richart 萬事達卡、JCB 全卡單筆滿 20 萬之加碼 0.1% 另列為獨立方案（campaign_id: richart_jcb_single_tx_bonus）；預計 2026/9/30 前入帳。",
+          "tags": [
+            "credit_card"
+          ]
+        },
+        {
+          "campaign_id": "richart_jcb_single_tx_bonus",
+          "title": "Richart 萬事達卡／JCB 全卡｜單筆滿 20 萬加碼",
+          "source_url": "https://mkp.taishinbank.com.tw/s/2026/tax/index.html",
+          "source_url_alt": "https://www.taishinbank.com.tw/TSB/personal/common/news/TSBankNews-007976/",
+          "source_id": null,
+          "eligible_cards": "Richart 萬事達卡、JCB 全卡（私銀／財管及一般卡友皆適用）",
+          "eligible_card_types": [
+            "credit"
+          ],
+          "eligible_card_ids": [
+            "bank812_richart_mastercard",
+            "bank812_jcb"
+          ],
+          "channel": [
+            "財政部網路繳稅服務網（Paytax）"
+          ],
+          "rebate": {
+            "requires_registration": true,
+            "period": "繳稅 2026/5/1~2026/6/4；登錄 2026/4/1 10:00–6/5 23:59",
+            "mode": "rate",
+            "rate": 0.1,
+            "fixed_unit": "元",
+            "min": 200000,
+            "cap_nt": 100000,
+            "cap_label": "加碼上限 100,000 元（與基礎回饋上限分開計算）"
+          },
+          "installment": null,
+          "notes": "可與台新基礎回饋（私銀 0.4% 或一般 0.1%）併計，加碼上限 100,000 元獨立於基礎回饋上限；單筆繳稅滿 20 萬才適用",
           "tags": [
             "credit_card"
           ]

--- a/src/lib/paymentOffers.ts
+++ b/src/lib/paymentOffers.ts
@@ -7,6 +7,7 @@ import { toNtd } from './rewardUnits'
 import type {
   AmountTier,
   BankListItem,
+  EligibilityRestriction,
   Offer,
   OfferTag,
   RebateMode,
@@ -20,6 +21,7 @@ interface RawRebate {
   mode?: RebateMode
   rate?: number
   fixed?: number
+  per_amount?: number
   fixed_unit?: string
   min?: number | null
   base_fixed?: number | null
@@ -39,6 +41,7 @@ interface RawCampaign {
   eligible_cards?: string | null
   eligible_card_types?: string[]
   eligible_card_ids?: string[]
+  eligibility_restrictions?: EligibilityRestriction[]
   channel?: string[] | null
   rebate?: RawRebate | null
   installment?: RawInstallment | null
@@ -111,6 +114,7 @@ function toOffer(bank: RawBank, c: RawCampaign, mode: RebateMode): Offer {
     mode,
     rate: r.rate,
     fixed: r.fixed,
+    per_amount: r.per_amount,
     fixed_unit: r.fixed_unit,
     min: r.min ?? null,
     base_fixed: r.base_fixed ?? null,
@@ -119,6 +123,7 @@ function toOffer(bank: RawBank, c: RawCampaign, mode: RebateMode): Offer {
     amount_tiers: r.amount_tiers,
     eligible_card_ids: eligibleCardIds,
     is_card_specific: eligibleCardIds.length > 0,
+    eligibility_restrictions: c.eligibility_restrictions ?? [],
     tags,
     requires_registration: r.requires_registration ?? false,
     period: r.period ?? null,
@@ -150,9 +155,31 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
   }
 
   const thresholdLabel =
-    (o.mode === 'fixed' || o.mode === 'rate') && o.min != null && o.min > 0
+    (o.mode === 'fixed' || o.mode === 'rate' || o.mode === 'unit_per_amount') &&
+    o.min != null &&
+    o.min > 0
       ? `單筆滿 ${fmtNT(o.min)}`
       : null
+
+  if (o.mode === 'unit_per_amount') {
+    const per = o.per_amount ?? 0
+    const step = o.fixed ?? 0
+    const raw = per > 0 ? Math.floor(amount / per) * step : 0
+    const cap = o.cap_nt ?? null
+    const capped = cap != null && raw > cap
+    const value = capped ? cap! : raw
+    const unit = o.fixed_unit ?? '元'
+    return {
+      applicable: true,
+      kind: 'unit_per_amount',
+      value,
+      value_ntd: toNtd(value, unit),
+      unit,
+      capped,
+      cap,
+      threshold_label: thresholdLabel,
+    }
+  }
 
   if (o.mode === 'fixed') {
     const unit = o.fixed_unit ?? '元'

--- a/src/lib/paymentOffers.ts
+++ b/src/lib/paymentOffers.ts
@@ -3,6 +3,7 @@
 
 import rawData from '../data/tax_payment_rewards_114.json'
 import { getCard } from './cardCatalog'
+import { toNtd } from './rewardUnits'
 import type {
   AmountTier,
   BankListItem,
@@ -131,10 +132,10 @@ function toOffer(bank: RawBank, c: RawCampaign, mode: RebateMode): Offer {
 // ── resolveOffer（移植自原型 Personalized Comparison.html L54-92） ───────────
 export function resolveOffer(o: Offer, amount: number): ResolveResult {
   if (o.mode === 'installment_only') {
-    return { applicable: true, value: null, kind: 'installment_only' }
+    return { applicable: true, value: null, value_ntd: null, kind: 'installment_only' }
   }
   if (o.mode === 'fee_only') {
-    return { applicable: true, value: null, kind: 'fee_only' }
+    return { applicable: true, value: null, value_ntd: null, kind: 'fee_only' }
   }
 
   const min = o.min ?? null
@@ -142,6 +143,7 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
     return {
       applicable: false,
       value: 0,
+      value_ntd: 0,
       kind: o.mode,
       reason: `需單筆滿 ${fmtNT(min)}`,
     }
@@ -153,11 +155,14 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
       : null
 
   if (o.mode === 'fixed') {
+    const unit = o.fixed_unit ?? '元'
+    const value = o.fixed ?? null
     return {
       applicable: true,
       kind: 'fixed',
-      value: o.fixed ?? null,
-      unit: o.fixed_unit ?? '元',
+      value,
+      value_ntd: toNtd(value, unit),
+      unit,
       threshold_label: thresholdLabel,
     }
   }
@@ -172,14 +177,16 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
       value = o.cap_nt + (o.base_fixed ?? 0)
       capped = true
     }
+    const unit = o.fixed_unit ?? '元'
     return {
       applicable: true,
       kind: 'rate',
       value,
+      value_ntd: toNtd(value, unit),
       rate,
       capped,
       cap: o.cap_nt,
-      unit: o.fixed_unit ?? '元',
+      unit,
       threshold_label: thresholdLabel,
     }
   }
@@ -192,6 +199,7 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
       return {
         applicable: false,
         value: 0,
+        value_ntd: 0,
         kind: o.mode,
         reason: `需單筆滿 ${fmtNT(lowestMin)}`,
       }
@@ -202,10 +210,12 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
       const raw = t.fixed
       const cap = t.cap_nt ?? null
       const capped = cap != null && raw > cap
+      const value = capped ? cap : raw
       return {
         applicable: true,
         kind: 'rate-tiered',
-        value: capped ? cap : raw,
+        value,
+        value_ntd: toNtd(value, t.fixed_unit),
         capped,
         cap,
         tier_label: t.label,
@@ -215,19 +225,22 @@ export function resolveOffer(o: Offer, amount: number): ResolveResult {
 
     const raw = (amount * t.rate) / 100
     const capped = t.cap_nt != null && raw > t.cap_nt
+    const value = capped ? t.cap_nt! : raw
+    const unit = o.fixed_unit ?? '元'
     return {
       applicable: true,
       kind: 'rate-tiered',
-      value: capped ? t.cap_nt! : raw,
+      value,
+      value_ntd: toNtd(value, unit),
       rate: t.rate,
       capped,
       cap: t.cap_nt,
       tier_label: t.label,
-      unit: o.fixed_unit ?? '元',
+      unit,
     }
   }
 
-  return { applicable: true, value: null, kind: o.mode }
+  return { applicable: true, value: null, value_ntd: null, kind: o.mode }
 }
 
 // ── 卡 picker 篩選契約 ──────────────────────────────────────────────────────

--- a/src/lib/rewardUnits.ts
+++ b/src/lib/rewardUnits.ts
@@ -1,0 +1,51 @@
+// 單位 → NT$ 換算與顯示策略。catalog 來源為 src/data/tax_payment_rewards_114.json
+// 的 reward_units 欄位，讓資料和換算規則同源維護。
+
+import rawData from '../data/tax_payment_rewards_114.json'
+
+export type RewardUnitKind = 'face_value' | 'cash_equivalent' | 'non_comparable'
+
+export interface RewardUnitMeta {
+  ntd_per_unit: number | null
+  kind: RewardUnitKind
+}
+
+const CATALOG: Record<string, RewardUnitMeta> =
+  (rawData as unknown as { reward_units?: Record<string, RewardUnitMeta> }).reward_units ?? {}
+
+const warned = new Set<string>()
+
+export function getUnitMeta(unit: string | undefined | null): RewardUnitMeta {
+  if (!unit) return { ntd_per_unit: 1, kind: 'face_value' }
+  const m = CATALOG[unit]
+  if (m) return m
+  if (import.meta.env.DEV && !warned.has(unit)) {
+    warned.add(unit)
+    console.warn(`[rewardUnits] unknown unit: ${unit}`)
+  }
+  return { ntd_per_unit: null, kind: 'non_comparable' }
+}
+
+export function toNtd(
+  value: number | null | undefined,
+  unit: string | undefined | null,
+): number | null {
+  if (value == null) return null
+  const { ntd_per_unit } = getUnitMeta(unit)
+  return ntd_per_unit == null ? null : value * ntd_per_unit
+}
+
+// 給「以 1 哩 ≈ NT$ 0.5 估算」這類比例顯示用，保留必要小數。
+export function fmtNtRatio(n: number): string {
+  const s = Number.isInteger(n) ? String(n) : n.toFixed(2).replace(/\.?0+$/, '')
+  return `NT$ ${s}`
+}
+
+// 「以 1 [單位] ≈ NT$ X 估算」的說明字串；ratio 為 1 時回 null（不顯示）。
+export function ratioHintText(unit: string | undefined | null): string | null {
+  const meta = getUnitMeta(unit)
+  if (meta.kind !== 'cash_equivalent' || meta.ntd_per_unit == null || meta.ntd_per_unit === 1) {
+    return null
+  }
+  return `以 1 ${unit} ≈ ${fmtNtRatio(meta.ntd_per_unit)} 估算`
+}

--- a/src/types/paymentOffers.ts
+++ b/src/types/paymentOffers.ts
@@ -76,6 +76,7 @@ export interface ResolveResult {
   applicable: boolean
   kind: RebateMode
   value: number | null          // 估算回饋金額；null 表示無金額（如僅分期）
+  value_ntd: number | null      // 排序與輔助顯示用 NT$ 等值；非「官方回饋金額」
   rate?: number                 // 適用回饋率
   capped?: boolean              // 是否觸發上限
   cap?: number | null

--- a/src/types/paymentOffers.ts
+++ b/src/types/paymentOffers.ts
@@ -5,10 +5,13 @@ export type RebateMode =
   | 'rate'              // 單一回饋率
   | 'rate-tiered'       // 階梯回饋率（依金額）
   | 'fixed'             // 定額（NT$ 或紅利點數等價）
+  | 'unit_per_amount'   // 每 N 元累積 M 單位（floor）
   | 'installment_only'  // 僅分期，不算金額
   | 'fee_only'          // 僅手續費說明
 
 export type OfferTag = 'taiwan_pay' | 'credit_card' | 'debit_card' | 'installment'
+
+export type EligibilityRestriction = 'new_customer' | 'special_member'
 
 export interface CatalogCard {
   card_id: string
@@ -51,7 +54,8 @@ export interface Offer {
 
   mode: RebateMode
   rate?: number                 // mode = 'rate' 必填
-  fixed?: number                // mode = 'fixed' 必填
+  fixed?: number                // mode = 'fixed' / 'unit_per_amount' 必填
+  per_amount?: number           // mode = 'unit_per_amount' 必填：每 N 元
   fixed_unit?: string           // 顯示單位字串（例：「元刷卡金」）
   min?: number | null           // 單筆門檻
   base_min?: number | null      // base_fixed 對應門檻
@@ -62,6 +66,8 @@ export interface Offer {
 
   eligible_card_ids: string[]   // 空陣列 = 全卡別；非空 = 限定 card_id
   is_card_specific: boolean     // 衍生：eligible_card_ids.length > 0
+
+  eligibility_restrictions: EligibilityRestriction[] // 身分限制；空陣列 = 無
 
   tags: OfferTag[]
   requires_registration?: boolean

--- a/tests/paymentOffers.test.ts
+++ b/tests/paymentOffers.test.ts
@@ -107,11 +107,143 @@ describe('resolveOffer rate-tiered 門檻過濾', () => {
   })
 })
 
+describe('resolveOffer unit_per_amount', () => {
+  const anaOffer = offers.find((o) => o.id === '822_ana_miles_rebate')
+
+  it('ANA campaign 已遷移到 unit_per_amount', () => {
+    expect(anaOffer).toBeTruthy()
+    expect(anaOffer!.mode).toBe('unit_per_amount')
+    expect(anaOffer!.per_amount).toBe(300)
+    expect(anaOffer!.fixed).toBe(1)
+    expect(anaOffer!.fixed_unit).toBe('哩')
+  })
+
+  it('amount = 100,000,000 → 333,333 哩（floor，非 0.333% 近似）', () => {
+    const r = resolveOffer(anaOffer!, 100_000_000)
+    expect(r.value).toBe(333_333)
+    expect(r.unit).toBe('哩')
+    expect(r.value_ntd).toBe(333_333 * 0.5)
+  })
+
+  it('amount = 299 → 0 哩；amount = 600 → 2 哩', () => {
+    expect(resolveOffer(anaOffer!, 299).value).toBe(0)
+    expect(resolveOffer(anaOffer!, 600).value).toBe(2)
+  })
+
+  it('合成 cap_nt 觸發 capped', () => {
+    const capped = { ...anaOffer!, cap_nt: 5 }
+    const r = resolveOffer(capped, 100_000)
+    expect(r.value).toBe(5)
+    expect(r.capped).toBe(true)
+    expect(r.cap).toBe(5)
+  })
+
+  it('資料完整性：所有 unit_per_amount campaign 都有 per_amount/fixed/fixed_unit', () => {
+    const all = offers.filter((o) => o.mode === 'unit_per_amount')
+    expect(all.length).toBeGreaterThan(0)
+    for (const o of all) {
+      expect(o.per_amount && o.per_amount > 0).toBeTruthy()
+      expect(o.fixed && o.fixed > 0).toBeTruthy()
+      expect(o.fixed_unit).toBeTruthy()
+    }
+  })
+})
+
 describe('deriveTags via loadOffers', () => {
   it('每個 offer tags 是 4 種已知值的子集', () => {
     const allowed = new Set(['taiwan_pay', 'credit_card', 'debit_card', 'installment'])
     for (const o of offers) {
       for (const t of o.tags) expect(allowed.has(t)).toBe(true)
     }
+  })
+})
+
+describe('eligibility_restrictions 標籤與排除篩選', () => {
+  function byCampaign(id: string) {
+    return offers.find((o) => o.id.endsWith(`_${id}`))
+  }
+
+  it('loader 預設無標註者為空陣列', () => {
+    const general = byCampaign('rebate_general')
+    expect(general).toBeTruthy()
+    expect(general!.eligibility_restrictions).toEqual([])
+  })
+
+  it('new_customer 標籤覆蓋預期 campaign', () => {
+    const ids = ['newnewbank_tax_rebate', 'jkopay_new_customer_bonus']
+    for (const id of ids) {
+      const o = byCampaign(id)
+      expect(o, `missing campaign ${id}`).toBeTruthy()
+      expect(o!.eligibility_restrictions).toContain('new_customer')
+    }
+  })
+
+  it('special_member 標籤涵蓋華南領航、富邦理財、台新財管等', () => {
+    const ids = [
+      'vip_rui',
+      'vip_meng',
+      'wealth_steady',
+      'wealth_rebate_installment',
+      'private_client',
+      'vip_top_tier',
+    ]
+    for (const id of ids) {
+      const o = byCampaign(id)
+      expect(o, `missing campaign ${id}`).toBeTruthy()
+      expect(o!.eligibility_restrictions).toContain('special_member')
+    }
+  })
+
+  it('「分期新戶」與「非私銀／財管會員」依規約不標', () => {
+    const installmentNewUser = byCampaign('online_installment_new_user')
+    expect(installmentNewUser).toBeTruthy()
+    expect(installmentNewUser!.eligibility_restrictions).toEqual([])
+
+    const taishinGeneral = byCampaign('general_rebate')
+    expect(taishinGeneral).toBeTruthy()
+    expect(taishinGeneral!.eligibility_restrictions).toEqual([])
+  })
+
+  function applyExclude(
+    src: typeof offers,
+    excludeNew: boolean,
+    excludeSpecial: boolean,
+  ) {
+    return src.filter((o) => {
+      if (excludeNew && o.eligibility_restrictions.includes('new_customer')) return false
+      if (excludeSpecial && o.eligibility_restrictions.includes('special_member'))
+        return false
+      return true
+    })
+  }
+
+  it('truth table: 兩 exclude 皆 false → 全集', () => {
+    expect(applyExclude(offers, false, false).length).toBe(offers.length)
+  })
+
+  it('truth table: 僅排除新戶 → 僅 new_customer offer 消失', () => {
+    const removed = offers.filter((o) =>
+      o.eligibility_restrictions.includes('new_customer'),
+    )
+    expect(removed.length).toBeGreaterThan(0)
+    const out = applyExclude(offers, true, false)
+    expect(out.length).toBe(offers.length - removed.length)
+    for (const r of removed) expect(out.find((o) => o.id === r.id)).toBeUndefined()
+  })
+
+  it('truth table: 僅排除特殊會員 → 僅 special_member offer 消失', () => {
+    const removed = offers.filter((o) =>
+      o.eligibility_restrictions.includes('special_member'),
+    )
+    expect(removed.length).toBeGreaterThan(0)
+    const out = applyExclude(offers, false, true)
+    expect(out.length).toBe(offers.length - removed.length)
+  })
+
+  it('truth table: 兩者皆排除 → 並集消失，殘餘皆無限制', () => {
+    const restricted = offers.filter((o) => o.eligibility_restrictions.length > 0)
+    const out = applyExclude(offers, true, true)
+    expect(out.length).toBe(offers.length - restricted.length)
+    for (const o of out) expect(o.eligibility_restrictions).toEqual([])
   })
 })

--- a/tests/resultList.test.tsx
+++ b/tests/resultList.test.tsx
@@ -3,6 +3,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ResultList } from '../src/components/payment/ResultList'
 import type { TypeFilterValue } from '../src/components/payment/TypeFilter'
+import type { ExcludeFilterValue } from '../src/components/payment/ExcludeFilter'
 import type { Offer } from '../src/types/paymentOffers'
 
 let container: HTMLDivElement
@@ -56,6 +57,7 @@ function makeOffer(overrides: Partial<Offer>): Offer {
     amount_tiers: overrides.amount_tiers,
     eligible_card_ids: overrides.eligible_card_ids ?? [],
     is_card_specific: overrides.is_card_specific ?? false,
+    eligibility_restrictions: overrides.eligibility_restrictions ?? [],
     tags: overrides.tags ?? ['credit_card'],
     requires_registration: overrides.requires_registration ?? false,
     period: overrides.period ?? null,
@@ -65,7 +67,17 @@ function makeOffer(overrides: Partial<Offer>): Offer {
   }
 }
 
-function renderResultList({ offers, amount = 500, query = '' }: { offers: Offer[]; amount?: number; query?: string }) {
+function renderResultList({
+  offers,
+  amount = 500,
+  query = '',
+  excludeFilter = { newCustomer: false, specialMember: false },
+}: {
+  offers: Offer[]
+  amount?: number
+  query?: string
+  excludeFilter?: ExcludeFilterValue
+}) {
   const nextRoot = createRoot(container)
   root = nextRoot
   act(() => {
@@ -74,6 +86,7 @@ function renderResultList({ offers, amount = 500, query = '' }: { offers: Offer[
         offers,
         amount,
         typeFilter: ALL_TYPES_ON,
+        excludeFilter,
         selectedCardIds: new Set<string>(),
         query,
         onQueryChange: () => {},
@@ -194,5 +207,92 @@ describe('ResultList applicable filtering', () => {
     renderResultList({ offers, amount: 500 })
 
     expect(getFirstCapValueText()).toBe('每戶回饋上限 20,000 元')
+  })
+})
+
+describe('ResultList exclude filter', () => {
+  const sampleOffers = (): Offer[] => [
+    makeOffer({
+      id: 'plain',
+      campaign_title: '一般活動',
+      min: 100,
+    }),
+    makeOffer({
+      id: 'newbie',
+      campaign_title: '新戶限定活動',
+      min: 100,
+      eligibility_restrictions: ['new_customer'],
+    }),
+    makeOffer({
+      id: 'vip',
+      campaign_title: '理財會員活動',
+      min: 100,
+      eligibility_restrictions: ['special_member'],
+    }),
+  ]
+
+  it('預設不勾排除 → 三筆 offer 全顯示', () => {
+    renderResultList({ offers: sampleOffers(), amount: 500 })
+    expect(container.textContent).toContain('一般活動')
+    expect(container.textContent).toContain('新戶限定活動')
+    expect(container.textContent).toContain('理財會員活動')
+    expect(container.textContent).toContain('共 3 個方案')
+  })
+
+  it('勾排除新戶 → 僅隱藏 new_customer offer', () => {
+    renderResultList({
+      offers: sampleOffers(),
+      amount: 500,
+      excludeFilter: { newCustomer: true, specialMember: false },
+    })
+    expect(container.textContent).toContain('一般活動')
+    expect(container.textContent).not.toContain('新戶限定活動')
+    expect(container.textContent).toContain('理財會員活動')
+    expect(container.textContent).toContain('共 2 個方案')
+  })
+
+  it('勾排除特殊會員 → 僅隱藏 special_member offer', () => {
+    renderResultList({
+      offers: sampleOffers(),
+      amount: 500,
+      excludeFilter: { newCustomer: false, specialMember: true },
+    })
+    expect(container.textContent).toContain('一般活動')
+    expect(container.textContent).toContain('新戶限定活動')
+    expect(container.textContent).not.toContain('理財會員活動')
+    expect(container.textContent).toContain('共 2 個方案')
+  })
+
+  it('兩者皆勾且全部被排 → 顯示帶「排除條件」的 empty state', () => {
+    const restrictedOnly: Offer[] = [
+      makeOffer({
+        id: 'newbie',
+        campaign_title: '新戶限定活動',
+        min: 100,
+        eligibility_restrictions: ['new_customer'],
+      }),
+      makeOffer({
+        id: 'vip',
+        campaign_title: '理財會員活動',
+        min: 100,
+        eligibility_restrictions: ['special_member'],
+      }),
+    ]
+    renderResultList({
+      offers: restrictedOnly,
+      amount: 500,
+      excludeFilter: { newCustomer: true, specialMember: true },
+    })
+    expect(container.textContent).toContain('目前沒有符合條件的方案，試著放寬類型、卡別或排除條件')
+    expect(container.textContent).not.toContain('新戶限定活動')
+    expect(container.textContent).not.toContain('理財會員活動')
+  })
+
+  it('未勾排除時，empty state 維持原文案', () => {
+    renderResultList({
+      offers: [],
+      amount: 500,
+    })
+    expect(container.textContent).toContain('目前沒有符合條件的方案，試著放寬類型或卡別篩選')
   })
 })

--- a/tests/rewardUnits.test.ts
+++ b/tests/rewardUnits.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest'
+import { fmtNtRatio, getUnitMeta, toNtd } from '../src/lib/rewardUnits'
+import { loadOffers, resolveOffer } from '../src/lib/paymentOffers'
+import rawData from '../src/data/tax_payment_rewards_114.json'
+
+describe('toNtd', () => {
+  it('台灣 Pay 紅利 10:1 → 600 點 = NT$60', () => {
+    expect(toNtd(600, '點台灣 Pay 紅利')).toBe(60)
+  })
+
+  it('元刷卡金 = 1:1', () => {
+    expect(toNtd(60, '元刷卡金')).toBe(60)
+  })
+
+  it('哩 = NT$0.5/哩', () => {
+    expect(toNtd(600, '哩')).toBe(300)
+  })
+
+  it('未知單位 → null', () => {
+    expect(toNtd(123, '未來新單位')).toBeNull()
+  })
+
+  it('undefined unit → 視為 NT$', () => {
+    expect(toNtd(50, undefined)).toBe(50)
+    expect(toNtd(50, '元')).toBe(50)
+  })
+
+  it('value 為 null/undefined → null', () => {
+    expect(toNtd(null, '元')).toBeNull()
+    expect(toNtd(undefined, '元')).toBeNull()
+  })
+})
+
+describe('getUnitMeta', () => {
+  it('元刷卡金 → face_value', () => {
+    expect(getUnitMeta('元刷卡金').kind).toBe('face_value')
+  })
+  it('點台灣 Pay 紅利 → cash_equivalent', () => {
+    expect(getUnitMeta('點台灣 Pay 紅利').kind).toBe('cash_equivalent')
+  })
+  it('哩 → cash_equivalent', () => {
+    const m = getUnitMeta('哩')
+    expect(m.kind).toBe('cash_equivalent')
+    expect(m.ntd_per_unit).toBe(0.5)
+  })
+  it('未知單位 → non_comparable + ntd_per_unit null', () => {
+    const m = getUnitMeta('未來新單位')
+    expect(m.kind).toBe('non_comparable')
+    expect(m.ntd_per_unit).toBeNull()
+  })
+})
+
+describe('fmtNtRatio', () => {
+  it('整數不顯示小數', () => {
+    expect(fmtNtRatio(1)).toBe('NT$ 1')
+  })
+  it('保留必要小數', () => {
+    expect(fmtNtRatio(0.5)).toBe('NT$ 0.5')
+    expect(fmtNtRatio(0.1)).toBe('NT$ 0.1')
+  })
+})
+
+describe('資料完整性：JSON 內所有 fixed_unit 必須在 catalog', () => {
+  const catalog = (
+    rawData as unknown as {
+      reward_units: Record<string, { ntd_per_unit: number | null; kind: string }>
+    }
+  ).reward_units
+
+  it('catalog 存在且非空', () => {
+    expect(catalog).toBeTruthy()
+    expect(Object.keys(catalog).length).toBeGreaterThan(0)
+  })
+
+  it('每個 fixed_unit / amount_tiers[].fixed_unit 都已登錄', () => {
+    const seen = new Set<string>()
+    for (const offer of loadOffers()) {
+      if (offer.fixed_unit) seen.add(offer.fixed_unit)
+      for (const t of offer.amount_tiers ?? []) {
+        if (t.kind === 'fixed' && t.fixed_unit) seen.add(t.fixed_unit)
+      }
+    }
+    const missing = [...seen].filter((u) => !(u in catalog))
+    expect(missing, `Units missing from reward_units catalog: ${missing.join(', ')}`).toEqual(
+      [],
+    )
+  })
+
+  it('catalog 每個 entry 的 kind 與 ntd_per_unit 格式合法', () => {
+    const validKinds = new Set(['face_value', 'cash_equivalent', 'non_comparable'])
+    for (const [unit, meta] of Object.entries(catalog)) {
+      expect(validKinds.has(meta.kind), `${unit} kind=${meta.kind}`).toBe(true)
+      if (meta.kind === 'non_comparable') {
+        expect(meta.ntd_per_unit, `${unit} non_comparable 應為 null`).toBeNull()
+      } else {
+        expect(typeof meta.ntd_per_unit, `${unit} 需數字`).toBe('number')
+        expect(Number.isFinite(meta.ntd_per_unit), `${unit} 需 finite`).toBe(true)
+        expect(meta.ntd_per_unit, `${unit} 需 > 0`).toBeGreaterThan(0)
+      }
+    }
+  })
+})
+
+describe('resolveOffer value_ntd', () => {
+  const offers = loadOffers()
+
+  it('fixed 模式：value_ntd 反映 unit 換算', () => {
+    const twPay = offers.find(
+      (o) => o.mode === 'fixed' && o.fixed_unit === '點台灣 Pay 紅利',
+    )
+    expect(twPay, '需有 fixed_unit=點台灣 Pay 紅利 的 offer').toBeTruthy()
+    const r = resolveOffer(twPay!, 60000)
+    expect(r.value).toBe(twPay!.fixed)
+    expect(r.value_ntd).toBe((twPay!.fixed ?? 0) * 0.1)
+  })
+
+  it('rate 模式：value_ntd = value（NT$）', () => {
+    const rate = offers.find((o) => o.mode === 'rate')
+    expect(rate, '需有 rate offer').toBeTruthy()
+    const r = resolveOffer(rate!, 60000)
+    expect(r.value_ntd).toBe(r.value)
+  })
+
+  it('installment_only / fee_only：value_ntd = null', () => {
+    const inst = offers.find((o) => o.mode === 'installment_only')
+    if (inst) {
+      const r = resolveOffer(inst, 60000)
+      expect(r.value_ntd).toBeNull()
+    }
+    const fee = offers.find((o) => o.mode === 'fee_only')
+    if (fee) {
+      const r = resolveOffer(fee, 60000)
+      expect(r.value_ntd).toBeNull()
+    }
+  })
+})
+
+describe('排序：依 NT$ 等值排，而非原始 value', () => {
+  // 對應原 bug：600 點台灣 Pay 紅利 (≈ NT$60) 不應排到 100 元刷卡金之前。
+  // 構造 mock ResolveResult 走真實的 sort 比較邏輯（與 ResultList.sortRanked 同義）。
+  function sortByNtd<T extends { value_ntd: number | null }>(rows: T[]): T[] {
+    return [...rows].sort((a, b) => {
+      const va = a.value_ntd ?? -Infinity
+      const vb = b.value_ntd ?? -Infinity
+      return vb - va
+    })
+  }
+
+  it('600 點台灣 Pay 紅利 (≈NT$60) 排在 NT$100 刷卡金之後', () => {
+    const twPay = { id: 'twPay', value: 600, value_ntd: toNtd(600, '點台灣 Pay 紅利') }
+    const card = { id: 'card', value: 100, value_ntd: toNtd(100, '元刷卡金') }
+    const sorted = sortByNtd([twPay, card])
+    expect(sorted[0].id).toBe('card')
+    expect(sorted[1].id).toBe('twPay')
+  })
+
+  it('600 哩 (≈NT$300) 排在 NT$100 刷卡金之前', () => {
+    const mile = { id: 'mile', value: 600, value_ntd: toNtd(600, '哩') }
+    const card = { id: 'card', value: 100, value_ntd: toNtd(100, '元刷卡金') }
+    const sorted = sortByNtd([mile, card])
+    expect(sorted[0].id).toBe('mile')
+  })
+
+  it('value_ntd = null 的方案排到最後', () => {
+    const unknown = { id: 'unknown', value: 999, value_ntd: null }
+    const card = { id: 'card', value: 1, value_ntd: 1 }
+    const sorted = sortByNtd([unknown, card])
+    expect(sorted[0].id).toBe('card')
+    expect(sorted[1].id).toBe('unknown')
+  })
+})


### PR DESCRIPTION
## Overview

This release ships the **繳稅回饋 (Payment Rewards)** page — a new tool that
lets users estimate cashback and installment options from Taiwan banks for
income-tax payments — along with a series of data accuracy fixes discovered
during testing.

## What's included

### New: Payment Rewards page (`/payment`)

- **Amount input** — user enters their tax amount; results appear below.
- **TypeFilter** — filter by reward type (credit card, debit card, installment,
  Taiwan Pay).
- **CardPicker** — filter by the user's own cards; narrows results to relevant
  banks and specific-card campaigns.
- **ResultList** — ranked list of offers (highest estimated reward first), with
  a "top reward" highlight card and free-text search. Offer details include
  reward rate/amount, cap, installment terms, and registration status.
- All inputs persisted to `localStorage` across sessions.
- Contact email added to site footer.

### Data (`tax_payment_rewards_114.json` + `card_catalog_114.json`)

- 114-year (2026) campaigns for all major Taiwan banks, covering rebates,
  tiered rewards, fixed bonuses, installment-only, and fee-only modes.
- Card catalog with 100+ card entries linked to campaigns via `card_id`.

### Bug fixes (post-launch)

| PR | Fix |
|---|---|
| #86 | Normalize all reward values to NTD before sorting, so miles/points offers rank correctly |
| #84 | Filter out `rate-tiered` offers when the tax amount falls below all tier minimums |
| #87 | Correct Taishin Richart/JCB single-transaction bonus campaign data; fix 808 PxPay rate |
| — | Replace ANA/China Airlines miles rate approximation with exact floor-based `unit_per_amount` calc |

### Tests

388 tests covering offer loading, card filtering, reward resolution (all modes
including `unit_per_amount`), reward-unit conversion, CardPicker UI, ResultList
rendering, and schema data integrity.

## Breaking changes

None. The payment page is a new route; no existing pages were modified beyond
navigation and footer updates.