### PR TITLE
ci: throttle Dependabot PRs and sync release bumps to dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "dev"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -12,6 +15,9 @@ updates:
       interval: "weekly"
     target-branch: "dev"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,12 @@ jobs:
           else
             echo "bumped=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Sync bump back to dev
+        if: steps.detect.outputs.bumped == 'true'
+        run: |
+          git checkout dev
+          git merge origin/main --no-edit
+          git push origin dev
       - name: Release
         if: steps.detect.outputs.bumped == 'true'
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
## Summary

- Add Dependabot cooldowns for both `github-actions` and `npm` updates targeting `dev` (3 days default, 7 days for semver-major).
- After a release workflow bumps `main`, merge `origin/main` into `dev` and push so `dev` picks up the version bump without a manual sync.

## Test plan

- [ ] Confirm Dependabot config validates (cooldown keys accepted for both ecosystems).
- [ ] Dry-run or review the release workflow: when `bumped=true`, the new step checks out `dev`, merges `origin/main`, and pushes.
- [ ] Verify no duplicate release runs if `main` did not advance.