### PR TITLE
ci(dependabot): remove invalid settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     target-branch: "dev"
     cooldown:
       default-days: 3
-      semver-major-days: 7
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
More info:

```
Your .github/dependabot.yml contained invalid details

Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/updates/0/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
Please update the config file to conform with Dependabot's specification.
```