### PR TITLE
ci(pages-preview): fix racy PR-preview cleanup on merge

### DIFF
--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -66,17 +66,40 @@ jobs:
     concurrency:
       group: github-pages-previews
       cancel-in-progress: false
-      queue: max
     steps:
       - uses: actions/checkout@v6
 
+      - name: Guard against stale dev build
+        id: guard
+        uses: actions/github-script@v9
+        with:
+          script: |
+            if (context.eventName === 'workflow_dispatch') {
+              core.setOutput('should_publish', 'true')
+              return
+            }
+            const { data: branch } = await github.rest.repos.getBranch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'dev',
+            })
+            const liveSha = branch.commit.sha
+            const wantSha = context.sha
+            const shouldPublish = liveSha === wantSha
+            if (!shouldPublish) {
+              core.info(`Skipping deploy: dev HEAD=${liveSha} is newer than this run ${wantSha}`)
+            }
+            core.setOutput('should_publish', String(shouldPublish))
+
       - name: Download dev build
+        if: steps.guard.outputs.should_publish == 'true'
         uses: actions/download-artifact@v7
         with:
           name: pages-build-dev
           path: pages-build
 
       - name: Deploy dev test site
+        if: steps.guard.outputs.should_publish == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -157,17 +180,35 @@ jobs:
     concurrency:
       group: github-pages-previews
       cancel-in-progress: false
-      queue: max
     steps:
       - uses: actions/checkout@v6
 
+      - name: Guard against closed or stale PR
+        id: guard
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ github.event.pull_request.number }},
+            })
+            const wantSha = '${{ github.event.pull_request.head.sha }}'
+            const shouldPublish = pr.state === 'open' && pr.head.sha === wantSha
+            if (!shouldPublish) {
+              core.info(`Skipping deploy: PR state=${pr.state} head=${pr.head.sha} want=${wantSha}`)
+            }
+            core.setOutput('should_publish', String(shouldPublish))
+
       - name: Download PR preview build
+        if: steps.guard.outputs.should_publish == 'true'
         uses: actions/download-artifact@v7
         with:
           name: pages-build-pr-${{ github.event.pull_request.number }}
           path: pages-build
 
       - name: Deploy PR preview
+        if: steps.guard.outputs.should_publish == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -201,6 +242,7 @@ jobs:
           fi
 
       - name: Comment preview URL
+        if: steps.guard.outputs.should_publish == 'true'
         uses: actions/github-script@v9
         with:
           script: |
@@ -238,7 +280,6 @@ jobs:
     concurrency:
       group: github-pages-previews
       cancel-in-progress: false
-      queue: max
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Problem

Merged PRs sometimes leave an orphaned `pr-preview/pr-N/` directory on the
`gh-pages` branch — the auto-cleanup-on-close does not reliably remove the
preview. Live proof: PR #112 is merged but `gh-pages:pr-preview/pr-112` still
exists, with no `deploy: remove pr-112 preview` commit.

## Root cause

The earlier build/publish split turned the single preview job into
`build-pr-preview` → `publish-pr-preview` (`needs: build-pr-preview`). On a
merge, two events fire almost together:

- `synchronize` → `build-pr-preview` (~47s) → `publish-pr-preview` deploys `pr-N`
- `closed` → `cleanup-pr-preview` removes `pr-N`

`cleanup-pr-preview` has no `needs`, so it grabs the shared
`github-pages-previews` concurrency lock instantly and finishes as a no-op
**before the preview is even deployed**; the build-gated `publish-pr-preview`
then deploys `pr-N` afterward → orphan. The shared concurrency group does not
help, because the two jobs never overlap in time — it's a pure ordering race.

`#112` timeline: `cleanup` ran 03:59:22–26 (no-op), `publish` deployed pr-112 at
04:00:00.

This is a regression vs the old single-job design, where the deploy job grabbed
the lock immediately on `synchronize` and held it through build+push, so the
`closed` cleanup queued behind it and ran last (pr-102…pr-108 all cleaned up).

## Fix

Keep the build/publish split, but make `publish-pr-preview` refuse to deploy
when the preview is no longer the wanted state:

- New **guard** step (`actions/github-script`) sets `should_publish=true` only
  when the PR is still `open` **and** its live head SHA still equals the run's
  head SHA. The SHA check also closes a second race where two `synchronize`
  builds finish out of order and an older artifact deploys after a newer one.
- The **Download**, **Deploy**, and **Comment** steps are gated on
  `should_publish` (gating the comment avoids posting a preview URL for a
  closed/superseded PR).
- Analogous guard on `publish-dev`: skip when `origin/dev` HEAD has advanced
  past this run's SHA, except on `workflow_dispatch`.
- Removed the invalid `queue: max` concurrency key from all three blocks.

## Notes / residual

The managed `pages build and deployment @ gh-pages` runs that show *"Canceling
since a higher priority waiting request…"* are GitHub's own Pages publish
pipeline, not this workflow — harmless (gh-pages is cumulative) and unrelated to
the orphan bug.

A small non-atomic window remains: a new `synchronize` arriving after the guard
passes but before the push can briefly publish a stale preview; the next
successful publish corrects it. Fully eliminating this would require per-PR
concurrency (`cancel-in-progress: true`) plus a fetch/rebase/retry loop on the
`gh-pages` push — deferred unless it proves necessary.

## Verification

- `actionlint .github/workflows/pages-preview.yml` — clean.
- End-to-end: open a throwaway PR against `dev`, confirm the preview deploys and
  the comment appears, then merge and confirm `cleanup-pr-preview` removes
  `pr-N` and the late `publish-pr-preview` logs `Skipping deploy: PR state=...`
  instead of redeploying.

> Note: `pr-112` is already orphaned from before this fix and should be removed
> from `gh-pages` separately.